### PR TITLE
Renombrar identificadores y variables en constructores y controladores

### DIFF
--- a/Controllers/DiagramaErController.cs
+++ b/Controllers/DiagramaErController.cs
@@ -95,7 +95,7 @@ public class DiagramaErController : Controller
             nombreBD = await _restaurador.RestaurarAsync(rutaBak, "ER");
 
             // 2) Leer el esquema de la BD restaurada (tablas, columnas, PKs, FKs...).
-            var snap = await _lector.LeerAsync(nombreBD);
+            var instantanea = await _lector.LeerAsync(nombreBD);
 
             // 2.b) Construir cadena de conexión hacia la BD restaurada.
             //     (Se usa para leer/guardar elecciones EER en esa misma BD).
@@ -103,17 +103,17 @@ public class DiagramaErController : Controller
 
             // 3) ER (Chen): generar Mermaid del modelo relacional.
             ViewBag.NombreBD = nombreBD;
-            ViewBag.Mermaid = _constructor.Construir(snap);
+            ViewBag.Mermaid = _constructor.Construir(instantanea);
 
             // 4) EER: detectar jerarquías de subtipos mediante heurística PK=FK (FK UNIQUE).
-            var jerarquias = InferenciaEER.DetectarJerarquias(snap);
+            var jerarquias = InferenciaEER.DetectarJerarquias(instantanea);
 
             // 4.b) Aplicar elecciones guardadas previamente (si existen) desde la BD restaurada.
-            var choices = await EERChoicesRestored.LoadChoicesAsync(cnnRestaurada);
+            var elecciones = await EERChoicesRestored.LoadChoicesAsync(cnnRestaurada);
             foreach (var j in jerarquias)
             {
                 var subsCsv = string.Join(",", j.Subtipos.OrderBy(x => x, StringComparer.OrdinalIgnoreCase));
-                var c = choices.FirstOrDefault(x =>
+                var c = elecciones.FirstOrDefault(x =>
                     x.sup.Equals(j.Supertipo, StringComparison.OrdinalIgnoreCase) &&
                     x.subs.Equals(subsCsv, StringComparison.OrdinalIgnoreCase));
 
@@ -187,23 +187,23 @@ public class DiagramaErController : Controller
     {
         try
         {
-            // 1) Guardar elecciones en la BD restaurada (tabla interna de choices).
+            // 1) Guardar elecciones en la BD restaurada (tabla interna de elecciones).
             var cnnRestaurada = EERChoicesRestored.BuildCnnToRestoredDb(_cfg, NombreBD);
             await EERChoicesRestored.SaveChoicesAsync(cnnRestaurada, Disyuncion, Totalidad, SubtypesCsv);
 
             // 2) Releer esquema y reconstruir diagramas (ER + EER) tras aplicar elecciones.
-            var snap = await _lector.LeerAsync(NombreBD);
+            var instantanea = await _lector.LeerAsync(NombreBD);
 
             ViewBag.NombreBD = NombreBD;
-            ViewBag.Mermaid = _constructor.Construir(snap);
+            ViewBag.Mermaid = _constructor.Construir(instantanea);
 
-            var jerarquias = InferenciaEER.DetectarJerarquias(snap);
+            var jerarquias = InferenciaEER.DetectarJerarquias(instantanea);
 
-            var choices = await EERChoicesRestored.LoadChoicesAsync(cnnRestaurada);
+            var elecciones = await EERChoicesRestored.LoadChoicesAsync(cnnRestaurada);
             foreach (var j in jerarquias)
             {
                 var subsCsv = string.Join(",", j.Subtipos.OrderBy(x => x, StringComparer.OrdinalIgnoreCase));
-                var c = choices.FirstOrDefault(x =>
+                var c = elecciones.FirstOrDefault(x =>
                     x.sup.Equals(j.Supertipo, StringComparison.OrdinalIgnoreCase) &&
                     x.subs.Equals(subsCsv, StringComparison.OrdinalIgnoreCase));
 

--- a/Controllers/RelacionalController.cs
+++ b/Controllers/RelacionalController.cs
@@ -28,9 +28,9 @@ public class RelacionalController : Controller
 
         try
         {
-            var snap = await _lector.LeerAsync(nombreBD);
+            var instantanea = await _lector.LeerAsync(nombreBD);
             ViewBag.NombreBD = nombreBD;
-            ViewBag.MermaidRel = _constructorRel.Construir(snap);
+            ViewBag.MermaidRel = _constructorRel.Construir(instantanea);
             return View();
         }
         catch (Exception ex)

--- a/Services/ConstructorDiagramaChen.cs
+++ b/Services/ConstructorDiagramaChen.cs
@@ -22,7 +22,7 @@ public class ConstructorDiagramaChen
     /// - Si no inicia con letra, antepone "N_".
     /// - Limita a 60 caracteres (Mermaid puede romper con IDs larguísimos).
     /// </summary>
-    private static string San(string? id)
+    private static string SanearIdMermaid(string? id)
     {
         var s = id ?? "X";
         s = _idBad.Replace(s, "_");
@@ -36,7 +36,7 @@ public class ConstructorDiagramaChen
     /// Escapa texto para que no rompa el parser de Mermaid:
     /// - Backslashes, comillas, saltos de línea y llaves.
     /// </summary>
-    private static string Esc(string? txt)
+    private static string EscaparTextoMermaid(string? txt)
     {
         if (string.IsNullOrEmpty(txt)) return "";
         return txt
@@ -77,13 +77,13 @@ public class ConstructorDiagramaChen
             if (ocultas.Contains(t.Nombre)) continue; // 👈 filtra EER_UserChoices
             if (s.TablasUnionMuchosAMuchos.Contains(t.Nombre)) continue;
 
-            var entId = San(t.Nombre);
-            sb.AppendLine($"  {entId}[{Esc(t.Nombre)}]:::entidad");
+            var entId = SanearIdMermaid(t.Nombre);
+            sb.AppendLine($"  {entId}[{EscaparTextoMermaid(t.Nombre)}]:::entidad");
 
             foreach (var c in s.Columnas.Where(x => x.Tabla == t.Nombre))
             {
-                var attrId = $"{entId}__{San(c.Nombre)}";
-                sb.AppendLine($"  {attrId}(({Esc(c.Nombre)})):::atributo");
+                var attrId = $"{entId}__{SanearIdMermaid(c.Nombre)}";
+                sb.AppendLine($"  {attrId}(({EscaparTextoMermaid(c.Nombre)})):::atributo");
 
                 if (c.EsPk) sb.AppendLine($"  class {attrId} clave;");
                 else if (c.EsUnicoCandidato) sb.AppendLine($"  class {attrId} unico;");
@@ -99,18 +99,18 @@ public class ConstructorDiagramaChen
             if (ocultas.Contains(fk.TablaPadre) || ocultas.Contains(fk.TablaHija)) continue; // 👈 filtra
             if (s.TablasUnionMuchosAMuchos.Contains(fk.TablaHija)) continue;
 
-            var relId = $"REL_{r++}_{San(fk.Nombre)}";
-            sb.AppendLine($"  {relId}{{{{{Esc(fk.Nombre)}}}}}:::relacion");
-            sb.AppendLine($"  {San(fk.TablaPadre)} -- \"1\" --> {relId}");
+            var relId = $"REL_{r++}_{SanearIdMermaid(fk.Nombre)}";
+            sb.AppendLine($"  {relId}{{{{{EscaparTextoMermaid(fk.Nombre)}}}}}:::relacion");
+            sb.AppendLine($"  {SanearIdMermaid(fk.TablaPadre)} -- \"1\" --> {relId}");
 
             string mult = fk.HijaEsUnica
                 ? (fk.HijaTodasNoNulas ? "1" : "0..1")
                 : (fk.HijaTodasNoNulas ? "1..N" : "0..N");
 
             if (fk.HijaTodasNoNulas)
-                sb.AppendLine($"  {relId} -- \"{mult}\" --> {San(fk.TablaHija)}");
+                sb.AppendLine($"  {relId} -- \"{mult}\" --> {SanearIdMermaid(fk.TablaHija)}");
             else
-                sb.AppendLine($"  {relId} -. \"{mult}\" .-> {San(fk.TablaHija)}");
+                sb.AppendLine($"  {relId} -. \"{mult}\" .-> {SanearIdMermaid(fk.TablaHija)}");
         }
 
         // -------- Relaciones M:N --------
@@ -125,11 +125,11 @@ public class ConstructorDiagramaChen
 
             if (padres.Count == 2)
             {
-                var relId = $"MN_{San(jt)}";
-                sb.AppendLine($"  {relId}{{{{{Esc(jt)}}}}}:::relacion");
+                var relId = $"MN_{SanearIdMermaid(jt)}";
+                sb.AppendLine($"  {relId}{{{{{EscaparTextoMermaid(jt)}}}}}:::relacion");
 
-                sb.AppendLine($"  {San(padres[0])} -- \"1..N\" --> {relId}");
-                sb.AppendLine($"  {relId} -- \"1..N\" --> {San(padres[1])}");
+                sb.AppendLine($"  {SanearIdMermaid(padres[0])} -- \"1..N\" --> {relId}");
+                sb.AppendLine($"  {relId} -- \"1..N\" --> {SanearIdMermaid(padres[1])}");
 
                 var fkCols = new HashSet<string>(
                     s.LlavesForaneas.Where(f => f.TablaHija == jt)
@@ -139,8 +139,8 @@ public class ConstructorDiagramaChen
                 var attrsRelacion = s.Columnas.Where(c => c.Tabla == jt && !fkCols.Contains(c.Nombre));
                 foreach (var c in attrsRelacion)
                 {
-                    var aid = $"{San(jt)}__{San(c.Nombre)}";
-                    sb.AppendLine($"  {aid}(({Esc(c.Nombre)})):::atributo");
+                    var aid = $"{SanearIdMermaid(jt)}__{SanearIdMermaid(c.Nombre)}";
+                    sb.AppendLine($"  {aid}(({EscaparTextoMermaid(c.Nombre)})):::atributo");
                     if (c.EsPk) sb.AppendLine($"  class {aid} clave;");
                     sb.AppendLine($"  {aid} --- {relId}");
                 }

--- a/Services/ConstructorDiagramaRelacional.cs
+++ b/Services/ConstructorDiagramaRelacional.cs
@@ -8,7 +8,7 @@ public class ConstructorDiagramaRelacional
 {
     private static readonly Regex _idBad = new(@"[^A-Za-z0-9_]", RegexOptions.Compiled);
 
-    private static string San(string? id)
+    private static string SanearIdMermaid(string? id)
     {
         var s = id ?? "X";
         s = _idBad.Replace(s, "_");
@@ -18,7 +18,7 @@ public class ConstructorDiagramaRelacional
     }
 
     // Escapar caracteres que rompen erDiagram, incluidas comillas
-    private static string Esc(string? txt)
+    private static string EscaparTextoMermaid(string? txt)
     {
         if (string.IsNullOrEmpty(txt)) return "";
         return txt.Replace("\r", " ")
@@ -55,14 +55,14 @@ public class ConstructorDiagramaRelacional
         var fksPorTabla = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
         foreach (var fk in s.LlavesForaneas)
         {
-            if (!fksPorTabla.TryGetValue(fk.TablaHija, out var set))
+            if (!fksPorTabla.TryGetValue(fk.TablaHija, out var conjunto))
             {
-                set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-                fksPorTabla[fk.TablaHija] = set;
+                conjunto = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                fksPorTabla[fk.TablaHija] = conjunto;
             }
 
             foreach (var col in fk.ColumnasHijaCsv.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
-                set.Add(col);
+                conjunto.Add(col);
         }
 
         // ------------------------- Tablas + columnas ------------------------------
@@ -70,11 +70,11 @@ public class ConstructorDiagramaRelacional
         {
             if (ocultas.Contains(t)) continue;
 
-            // Hash de FKs de esta tabla (si no tiene, set vacío)
+            // Hash de FKs de esta tabla (si no tiene, conjunto vacío)
             fksPorTabla.TryGetValue(t, out var fkCols);
             fkCols ??= new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-            sb.AppendLine($"  {San(t)} {{");
+            sb.AppendLine($"  {SanearIdMermaid(t)} {{");
             foreach (var c in s.Columnas.Where(c => c.Tabla == t))
             {
                 var tipo = MapTipo(c.Tipo);
@@ -86,7 +86,7 @@ public class ConstructorDiagramaRelacional
                 if (c.EsUnicoCandidato && !c.EsPk) flags.Add("UK"); // si ya es PK, no repito UK
 
                 var flagTxt = flags.Count > 0 ? " " + string.Join(" ", flags) : "";
-                sb.AppendLine($"    {Esc(tipo)} {Esc(c.Nombre)}{flagTxt}");
+                sb.AppendLine($"    {EscaparTextoMermaid(tipo)} {EscaparTextoMermaid(c.Nombre)}{flagTxt}");
             }
             sb.AppendLine("  }");
         }
@@ -101,8 +101,8 @@ public class ConstructorDiagramaRelacional
                 ? (fk.HijaTodasNoNulas ? "||" : "o|")   // 1:1 o 0..1
                 : (fk.HijaTodasNoNulas ? "|{" : "o{");  // 1:N o 0..N
 
-            var etiqueta = Esc(fk.Nombre);
-            sb.AppendLine($"  {San(fk.TablaPadre)} {left}--{right} {San(fk.TablaHija)} : \"{etiqueta}\"");
+            var etiqueta = EscaparTextoMermaid(fk.Nombre);
+            sb.AppendLine($"  {SanearIdMermaid(fk.TablaPadre)} {left}--{right} {SanearIdMermaid(fk.TablaHija)} : \"{etiqueta}\"");
         }
 
         return sb.ToString();

--- a/Services/InferenciaEER_Overrides.cs
+++ b/Services/InferenciaEER_Overrides.cs
@@ -12,18 +12,18 @@ public static class InferenciaEER_Overrides
     /// Carga elecciones (sup, subs, dis, tot) y sobreescribe Disyunción/Totalidad
     /// en la lista de jerarquías. Marca la evidencia como “Elección del usuario aplicada.”.
     /// </summary>
-    /// <param name="loadChoices">Función que retorna la lista persistida de elecciones.</param>
+    /// <param name="cargarElecciones">Función que retorna la lista persistida de elecciones.</param>
     /// <param name="jerarquias">Jerarquías detectadas a modificar in place.</param>
     public static async Task AplicarOverridesAsync(
-        Func<Task<List<(string sup, string subs, string dis, string tot)>>> loadChoices,
+        Func<Task<List<(string sup, string subs, string dis, string tot)>>> cargarElecciones,
         List<JerarquiaEer> jerarquias)
     {
-        var choices = await loadChoices();
+        var elecciones = await cargarElecciones();
 
         foreach (var j in jerarquias)
         {
             var subsCsv = string.Join(",", j.Subtipos.OrderBy(x => x, StringComparer.OrdinalIgnoreCase));
-            var c = choices.FirstOrDefault(x =>
+            var c = elecciones.FirstOrDefault(x =>
                 x.sup.Equals(j.Supertipo, StringComparison.OrdinalIgnoreCase) &&
                 x.subs.Equals(subsCsv, StringComparison.OrdinalIgnoreCase));
 


### PR DESCRIPTION
## Summary
- Renamed helper methods to **SanearIdMermaid** and **EscaparTextoMermaid** in diagram constructors and updated usages.
- Replaced English variable names with Spanish equivalents like `instantanea`, `elecciones` and `conjunto` across controllers and services.
- Ensured MVC controllers compile with new identifiers.

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68b392cc72ac83309fcf5290f4055d02