### PR TITLE
Document diagram rules and hide internal table

### DIFF
--- a/Services/ConstructorDiagramaChen.cs
+++ b/Services/ConstructorDiagramaChen.cs
@@ -57,7 +57,8 @@ public class ConstructorDiagramaChen
     {
         var sb = new StringBuilder();
 
-        // Tablas internas que no deben dibujarse
+        // Tablas internas que no deben dibujarse en ningún diagrama
+        // (p.ej. EER_UserChoices con elecciones de usuario).
         var ocultas = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
     {
         "EER_UserChoices"
@@ -103,6 +104,11 @@ public class ConstructorDiagramaChen
             sb.AppendLine($"  {relId}{{{{{Esc(fk.Nombre)}}}}}:::relacion");
             sb.AppendLine($"  {San(fk.TablaPadre)} -- \"1\" --> {relId}");
 
+            // Reglas de cardinalidad Chen basadas en la FK:
+            //   HijaEsUnica && HijaTodasNoNulas -> "1"
+            //   HijaEsUnica && !HijaTodasNoNulas -> "0..1"
+            //   !HijaEsUnica && HijaTodasNoNulas -> "1..N"
+            //   !HijaEsUnica && !HijaTodasNoNulas -> "0..N"
             string mult = fk.HijaEsUnica
                 ? (fk.HijaTodasNoNulas ? "1" : "0..1")
                 : (fk.HijaTodasNoNulas ? "1..N" : "0..N");

--- a/Services/ConstructorDiagramaRelacional.cs
+++ b/Services/ConstructorDiagramaRelacional.cs
@@ -4,6 +4,11 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Collections.Generic;
 
+/// <summary>
+/// Genera diagramas <c>erDiagram</c> de Mermaid usando notación crow's foot
+/// (relacional) a partir de una <see cref="InstantaneaEsquema"/> con tablas,
+/// columnas y llaves foráneas.
+/// </summary>
 public class ConstructorDiagramaRelacional
 {
     private static readonly Regex _idBad = new(@"[^A-Za-z0-9_]", RegexOptions.Compiled);
@@ -47,6 +52,8 @@ public class ConstructorDiagramaRelacional
     /// Genera Mermaid erDiagram (crow’s foot) a partir de InstantaneaEsquema.
     public string Construir(InstantaneaEsquema s)
     {
+        // Tablas internas que no deben verse en el diagrama
+        // (por ejemplo EER_UserChoices usada para opciones de usuario).
         var ocultas = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "EER_UserChoices" };
         var sb = new StringBuilder();
         sb.AppendLine("erDiagram");
@@ -96,7 +103,12 @@ public class ConstructorDiagramaRelacional
         {
             if (ocultas.Contains(fk.TablaPadre) || ocultas.Contains(fk.TablaHija)) continue;
 
-            var left = "||"; // padre: exactamente 1
+            var left = "||"; // Padre: exactamente 1
+            // Reglas de Mermaid erDiagram:
+            //   || : lado justo 1
+            //   o| : 0 o 1
+            //   |{ : 1 o muchos
+            //   o{ : 0 o muchos
             string right = fk.HijaEsUnica
                 ? (fk.HijaTodasNoNulas ? "||" : "o|")   // 1:1 o 0..1
                 : (fk.HijaTodasNoNulas ? "|{" : "o{");  // 1:N o 0..N

--- a/Services/LectorEsquemaSql.cs
+++ b/Services/LectorEsquemaSql.cs
@@ -115,6 +115,7 @@ public class LectorEsquemaSql
         {
             cmd.CommandText = @"
 WITH pkcols AS (
+  -- Columnas que conforman la clave primaria
   SELECT ic.object_id, ic.column_id
   FROM sys.key_constraints pk
   JOIN sys.index_columns ic
@@ -123,6 +124,7 @@ WITH pkcols AS (
   WHERE pk.[type] = 'PK'
 ),
 uqcols AS (
+  -- Columnas que participan en algún índice único (no PK)
   SELECT ic.object_id, ic.column_id
   FROM sys.indexes i
   JOIN sys.index_columns ic
@@ -162,6 +164,7 @@ ORDER BY t.name, c.column_id;";
         {
             cmd.CommandText = @"
 WITH fkcols AS (
+  -- Desglosa cada FK en sus columnas padre/hija
   SELECT fk.object_id AS fk_id, fk.name AS FK_Nombre,
          rt.name AS TablaPadre, t.name AS TablaHija,
          pc.name AS ColPadre, cc.name AS ColHija, cc.column_id
@@ -173,6 +176,7 @@ WITH fkcols AS (
   JOIN sys.columns cc ON cc.object_id = fkc.parent_object_id     AND cc.column_id = fkc.parent_column_id
 ),
 fkg AS (
+  -- Agrupa columnas por FK manteniendo el orden original
   SELECT fk_id,
          MAX(FK_Nombre)   AS FK_Nombre,
          MAX(TablaPadre)  AS TablaPadre,
@@ -183,7 +187,8 @@ fkg AS (
   GROUP BY fk_id
 ),
 uniq_hija AS (
-  -- Nota: i.is_unique incluye PKs; si quieres excluir PKs, agrega 'AND i.is_primary_key = 0'
+  -- Conjuntos de columnas hija cubiertos por algún índice único
+  -- Nota: i.is_unique incluye PKs; para excluirlas: 'AND i.is_primary_key = 0'
   SELECT t.name AS Tabla,
          STRING_AGG(c.name, ', ') WITHIN GROUP (ORDER BY ic.key_ordinal) AS Cols
   FROM sys.indexes i
@@ -194,8 +199,7 @@ uniq_hija AS (
   GROUP BY t.name
 ),
 fk_nullable AS (
-  -- ***FIX***: queremos 1 sólo si TODAS las columnas FK son NOT NULL.
-  -- Si alguna columna de la FK es nullable -> 0.
+  -- 1 solo si todas las columnas FK son NOT NULL (participación total)
   SELECT fkc.constraint_object_id AS fk_id,
          MIN(CASE WHEN c.is_nullable = 0 THEN 1 ELSE 0 END) AS AllNotNull
   FROM sys.foreign_key_columns fkc
@@ -235,6 +239,7 @@ ORDER BY g.TablaPadre, g.TablaHija;";
         {
             cmd.CommandText = @"
 WITH pkcols AS (
+  -- Cuenta columnas de la PK por tabla
   SELECT t.object_id, t.name AS Tabla, kc.name AS PKName, COUNT(*) AS PKCols
   FROM sys.key_constraints kc
   JOIN sys.tables t ON t.object_id = kc.parent_object_id
@@ -242,6 +247,7 @@ WITH pkcols AS (
   GROUP BY t.object_id, t.name, kc.name
 ),
 fkcount AS (
+  -- Número de FKs y tablas referenciadas por cada tabla
   SELECT t.object_id,
          COUNT(DISTINCT fk.object_id) AS FKs,
          COUNT(DISTINCT rt.name)      AS TablasReferenciadas


### PR DESCRIPTION
## Summary
- add summary and Mermaid cardinality docs to ConstructorDiagramaRelacional
- explain FK cardinality mapping in ConstructorDiagramaChen and skip internal EER_UserChoices table
- describe each SQL CTE in LectorEsquemaSql

## Testing
- `dotnet build`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68b392d30bec83308321a59f4028e951