### PR TITLE
Refactor diagram constructors into helper methods

### DIFF
--- a/Services/ConstructorDiagramaChen.cs
+++ b/Services/ConstructorDiagramaChen.cs
@@ -17,38 +17,6 @@ public class ConstructorDiagramaChen
     private static readonly Regex _idBad = new(@"[^A-Za-z0-9_]", RegexOptions.Compiled);
 
     /// <summary>
-    /// Sanea un identificador para que sea válido en Mermaid:
-    /// - Reemplaza caracteres no permitidos por "_".
-    /// - Si no inicia con letra, antepone "N_".
-    /// - Limita a 60 caracteres (Mermaid puede romper con IDs larguísimos).
-    /// </summary>
-    private static string San(string? id)
-    {
-        var s = id ?? "X";
-        s = _idBad.Replace(s, "_");
-        if (string.IsNullOrEmpty(s) || !char.IsLetter(s[0]))
-            s = "N_" + s;
-        if (s.Length > 60) s = s[..60];
-        return s;
-    }
-
-    /// <summary>
-    /// Escapa texto para que no rompa el parser de Mermaid:
-    /// - Backslashes, comillas, saltos de línea y llaves.
-    /// </summary>
-    private static string Esc(string? txt)
-    {
-        if (string.IsNullOrEmpty(txt)) return "";
-        return txt
-            .Replace("\\", "\\\\")   // backslash
-            .Replace("\"", "\\\"")   // comillas
-            .Replace("\r", " ")      // CR
-            .Replace("\n", " ")      // LF
-            .Replace("{", "\\{")     // llaves
-            .Replace("}", "\\}");    // llaves
-    }
-
-    /// <summary>
     /// Construye el diagrama Mermaid (flowchart LR) en notación tipo Chen.
     /// </summary>
     /// <param name="s">Instantánea del esquema (tablas, columnas, FKs, tablas puente, etc.).</param>
@@ -71,7 +39,16 @@ public class ConstructorDiagramaChen
         sb.AppendLine("classDef clave font-weight:bold,text-decoration:underline;");
         sb.AppendLine("classDef unico stroke-dasharray:3 2;");
 
-        // -------- Entidades --------
+        ConstruirEntidades(s, sb, ocultas);
+        ConstruirRelacionesBinarias(s, sb, ocultas);
+        ConstruirRelacionesMuchosAMuchos(s, sb, ocultas);
+        AgregarNotasEntidadesDebiles(s, sb, ocultas);
+
+        return sb.ToString();
+    }
+
+    private static void ConstruirEntidades(InstantaneaEsquema s, StringBuilder sb, HashSet<string> ocultas)
+    {
         foreach (var t in s.Tablas)
         {
             if (ocultas.Contains(t.Nombre)) continue; // 👈 filtra EER_UserChoices
@@ -91,8 +68,10 @@ public class ConstructorDiagramaChen
                 sb.AppendLine($"  {attrId} --- {entId}");
             }
         }
+    }
 
-        // -------- Relaciones binarias (FKs) --------
+    private static void ConstruirRelacionesBinarias(InstantaneaEsquema s, StringBuilder sb, HashSet<string> ocultas)
+    {
         int r = 0;
         foreach (var fk in s.LlavesForaneas)
         {
@@ -112,8 +91,10 @@ public class ConstructorDiagramaChen
             else
                 sb.AppendLine($"  {relId} -. \"{mult}\" .-> {San(fk.TablaHija)}");
         }
+    }
 
-        // -------- Relaciones M:N --------
+    private static void ConstruirRelacionesMuchosAMuchos(InstantaneaEsquema s, StringBuilder sb, HashSet<string> ocultas)
+    {
         foreach (var jt in s.TablasUnionMuchosAMuchos)
         {
             if (ocultas.Contains(jt)) continue; // 👈 filtra
@@ -146,12 +127,45 @@ public class ConstructorDiagramaChen
                 }
             }
         }
+    }
 
+    private static void AgregarNotasEntidadesDebiles(InstantaneaEsquema s, StringBuilder sb, HashSet<string> ocultas)
+    {
         foreach (var w in s.EntidadesDebiles)
             if (!ocultas.Contains(w)) // 👈 también aquí
                 sb.AppendLine($"  %% {w} es ENTIDAD DEBIL (PK incluye FK)");
-
-        return sb.ToString();
     }
 
+    /// <summary>
+    /// Sanea un identificador para que sea válido en Mermaid:
+    /// - Reemplaza caracteres no permitidos por "_".
+    /// - Si no inicia con letra, antepone "N_".
+    /// - Limita a 60 caracteres (Mermaid puede romper con IDs larguísimos).
+    /// </summary>
+    private static string San(string? id)
+    {
+        var s = id ?? "X";
+        s = _idBad.Replace(s, "_");
+        if (string.IsNullOrEmpty(s) || !char.IsLetter(s[0]))
+            s = "N_" + s;
+        if (s.Length > 60) s = s[..60];
+        return s;
+    }
+
+    /// <summary>
+    /// Escapa texto para que no rompa el parser de Mermaid:
+    /// - Backslashes, comillas, saltos de línea y llaves.
+    /// </summary>
+    private static string Esc(string? txt)
+    {
+        if (string.IsNullOrEmpty(txt)) return "";
+        return txt
+            .Replace("\\", "\\\\")   // backslash
+            .Replace("\"", "\\\"")   // comillas
+            .Replace("\r", " ")      // CR
+            .Replace("\n", " ")      // LF
+            .Replace("{", "\\{")     // llaves
+            .Replace("}", "\\}");    // llaves
+    }
 }
+

--- a/Services/ConstructorDiagramaRelacional.cs
+++ b/Services/ConstructorDiagramaRelacional.cs
@@ -8,6 +8,79 @@ public class ConstructorDiagramaRelacional
 {
     private static readonly Regex _idBad = new(@"[^A-Za-z0-9_]", RegexOptions.Compiled);
 
+    /// Genera Mermaid erDiagram (crow’s foot) a partir de InstantaneaEsquema.
+    public string Construir(InstantaneaEsquema s)
+    {
+        var ocultas = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "EER_UserChoices" };
+        var sb = new StringBuilder();
+        sb.AppendLine("erDiagram");
+
+        var fksPorTabla = ConstruirIndiceFkPorTabla(s);
+        ConstruirSeccionTablas(s, fksPorTabla, sb, ocultas);
+        ConstruirRelaciones(s, sb, ocultas);
+
+        return sb.ToString();
+    }
+
+    private static Dictionary<string, HashSet<string>> ConstruirIndiceFkPorTabla(InstantaneaEsquema s)
+    {
+        var fksPorTabla = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
+        foreach (var fk in s.LlavesForaneas)
+        {
+            if (!fksPorTabla.TryGetValue(fk.TablaHija, out var set))
+            {
+                set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                fksPorTabla[fk.TablaHija] = set;
+            }
+
+            foreach (var col in fk.ColumnasHijaCsv.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+                set.Add(col);
+        }
+        return fksPorTabla;
+    }
+
+    private static void ConstruirSeccionTablas(InstantaneaEsquema s, Dictionary<string, HashSet<string>> fksPorTabla, StringBuilder sb, HashSet<string> ocultas)
+    {
+        foreach (var t in s.Tablas.Select(x => x.Nombre))
+        {
+            if (ocultas.Contains(t)) continue;
+
+            fksPorTabla.TryGetValue(t, out var fkCols);
+            fkCols ??= new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            sb.AppendLine($"  {San(t)} {{");
+            foreach (var c in s.Columnas.Where(c => c.Tabla == t))
+            {
+                var tipo = MapTipo(c.Tipo);
+
+                var flags = new List<string>();
+                if (c.EsPk) flags.Add("PK");
+                if (fkCols.Contains(c.Nombre)) flags.Add("FK");
+                if (c.EsUnicoCandidato && !c.EsPk) flags.Add("UK");
+
+                var flagTxt = flags.Count > 0 ? " " + string.Join(" ", flags) : "";
+                sb.AppendLine($"    {Esc(tipo)} {Esc(c.Nombre)}{flagTxt}");
+            }
+            sb.AppendLine("  }");
+        }
+    }
+
+    private static void ConstruirRelaciones(InstantaneaEsquema s, StringBuilder sb, HashSet<string> ocultas)
+    {
+        foreach (var fk in s.LlavesForaneas)
+        {
+            if (ocultas.Contains(fk.TablaPadre) || ocultas.Contains(fk.TablaHija)) continue;
+
+            var left = "||"; // padre: exactamente 1
+            string right = fk.HijaEsUnica
+                ? (fk.HijaTodasNoNulas ? "||" : "o|")
+                : (fk.HijaTodasNoNulas ? "|{" : "o{");
+
+            var etiqueta = Esc(fk.Nombre);
+            sb.AppendLine($"  {San(fk.TablaPadre)} {left}--{right} {San(fk.TablaHija)} : \"{etiqueta}\"");
+        }
+    }
+
     private static string San(string? id)
     {
         var s = id ?? "X";
@@ -43,68 +116,4 @@ public class ConstructorDiagramaRelacional
         "varchar" or "nvarchar" => "varchar",
         _ => _idBad.Replace(t, "_") // simplifica tipos raros para Mermaid
     };
-
-    /// Genera Mermaid erDiagram (crow’s foot) a partir de InstantaneaEsquema.
-    public string Construir(InstantaneaEsquema s)
-    {
-        var ocultas = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "EER_UserChoices" };
-        var sb = new StringBuilder();
-        sb.AppendLine("erDiagram");
-
-        // --------- Índice: columnas FK por tabla (maneja FKs compuestas) ----------
-        var fksPorTabla = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
-        foreach (var fk in s.LlavesForaneas)
-        {
-            if (!fksPorTabla.TryGetValue(fk.TablaHija, out var set))
-            {
-                set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-                fksPorTabla[fk.TablaHija] = set;
-            }
-
-            foreach (var col in fk.ColumnasHijaCsv.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
-                set.Add(col);
-        }
-
-        // ------------------------- Tablas + columnas ------------------------------
-        foreach (var t in s.Tablas.Select(x => x.Nombre))
-        {
-            if (ocultas.Contains(t)) continue;
-
-            // Hash de FKs de esta tabla (si no tiene, set vacío)
-            fksPorTabla.TryGetValue(t, out var fkCols);
-            fkCols ??= new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-            sb.AppendLine($"  {San(t)} {{");
-            foreach (var c in s.Columnas.Where(c => c.Tabla == t))
-            {
-                var tipo = MapTipo(c.Tipo);
-
-                // Flags: PK / FK / UK (sin paréntesis; Mermaid los muestra como texto a la derecha)
-                var flags = new List<string>();
-                if (c.EsPk) flags.Add("PK");
-                if (fkCols.Contains(c.Nombre)) flags.Add("FK");
-                if (c.EsUnicoCandidato && !c.EsPk) flags.Add("UK"); // si ya es PK, no repito UK
-
-                var flagTxt = flags.Count > 0 ? " " + string.Join(" ", flags) : "";
-                sb.AppendLine($"    {Esc(tipo)} {Esc(c.Nombre)}{flagTxt}");
-            }
-            sb.AppendLine("  }");
-        }
-
-        // --------------------------- Relaciones (patas) ---------------------------
-        foreach (var fk in s.LlavesForaneas)
-        {
-            if (ocultas.Contains(fk.TablaPadre) || ocultas.Contains(fk.TablaHija)) continue;
-
-            var left = "||"; // padre: exactamente 1
-            string right = fk.HijaEsUnica
-                ? (fk.HijaTodasNoNulas ? "||" : "o|")   // 1:1 o 0..1
-                : (fk.HijaTodasNoNulas ? "|{" : "o{");  // 1:N o 0..N
-
-            var etiqueta = Esc(fk.Nombre);
-            sb.AppendLine($"  {San(fk.TablaPadre)} {left}--{right} {San(fk.TablaHija)} : \"{etiqueta}\"");
-        }
-
-        return sb.ToString();
-    }
 }


### PR DESCRIPTION
## Summary
- split diagram construction into focused helper methods for ER and relational diagrams
- order class members as fields, public methods, then private helpers

## Testing
- `dotnet build`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68b392d9de608330bda75288537da01d