### PR TITLE
refactor: externalize mermaid init and drop unused form

### DIFF
--- a/Views/DiagramaER/Resultado.cshtml
+++ b/Views/DiagramaER/Resultado.cshtml
@@ -24,13 +24,7 @@
 </div>
 
 <script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
-<script>
-    mermaid.initialize({
-      startOnLoad: true,
-      maxTextSize: 10000000,
-      securityLevel: 'loose'
-    });
-</script>
+<script src="~/js/mermaid-init.js"></script>
 
 @if (TempData["msg"] != null)
 {

--- a/Views/Relacional/ModeloR.cshtml
+++ b/Views/Relacional/ModeloR.cshtml
@@ -22,13 +22,7 @@
 }
 
 <script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
-<script>
-    mermaid.initialize({
-      startOnLoad: true,
-      securityLevel: 'loose',
-      maxTextSize: 10000000
-    });
-</script>
+<script src="~/js/mermaid-init.js"></script>
 
 <pre class="mermaid">
 @mermaidRel
@@ -41,8 +35,3 @@
   </textarea>
 </details>
 
-<!-- Botón opcional para exportar SQL -->
-<form asp-action="ExportarSql" method="post" class="mt-3">
-    <input type="hidden" name="nombreBD" value="@nombreBD" />
-    <button class="btn btn-success">Exportar SQL</button>
-</form>

--- a/wwwroot/js/mermaid-init.js
+++ b/wwwroot/js/mermaid-init.js
@@ -1,0 +1,5 @@
+mermaid.initialize({
+  startOnLoad: true,
+  maxTextSize: 10000000,
+  securityLevel: 'loose'
+});


### PR DESCRIPTION
## Summary
- centralize Mermaid initialization in `wwwroot/js/mermaid-init.js`
- load shared script from ER and relational views
- remove unused Exportar SQL form

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68b392eb07188330a1b5c853c5f841c3