### PR TITLE
Refactor diagram services for clarity

### DIFF
--- a/Services/ConstructorDiagramaChen.cs
+++ b/Services/ConstructorDiagramaChen.cs
@@ -1,157 +1,144 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
-using System.Text.RegularExpressions;
 
-/// <summary>
-/// Construye un diagrama ER en notación Chen usando sintaxis de Mermaid (flowchart),
-/// a partir de una instantánea del esquema (tablas, columnas, FKs, etc.).
-/// - Pinta entidades (cuadros), atributos (óvalos) y relaciones (rombos).
-/// - Dibuja cardinalidades 1, 0..1, 1..N, 0..N según la unicidad y nulabilidad de las FKs.
-/// - Trata tablas puente (M:N) como relaciones con atributos.
-/// </summary>
 public class ConstructorDiagramaChen
 {
-    // Regex para sanear IDs de nodos en Mermaid (solo letras, números y guion bajo).
-    private static readonly Regex _idBad = new(@"[^A-Za-z0-9_]", RegexOptions.Compiled);
-
-    /// <summary>
-    /// Sanea un identificador para que sea válido en Mermaid:
-    /// - Reemplaza caracteres no permitidos por "_".
-    /// - Si no inicia con letra, antepone "N_".
-    /// - Limita a 60 caracteres (Mermaid puede romper con IDs larguísimos).
-    /// </summary>
+    /// <summary>Sanea un identificador para Mermaid.</summary>
     private static string San(string? id)
     {
-        var s = id ?? "X";
-        s = _idBad.Replace(s, "_");
-        if (string.IsNullOrEmpty(s) || !char.IsLetter(s[0]))
-            s = "N_" + s;
-        if (s.Length > 60) s = s[..60];
-        return s;
+        var src = string.IsNullOrEmpty(id) ? "X" : id;
+        var sb = new StringBuilder(src.Length);
+        foreach (var ch in src)
+            sb.Append(char.IsLetterOrDigit(ch) || ch == '_' ? ch : '_');
+        var s = sb.ToString();
+        if (s.Length == 0 || !char.IsLetter(s[0])) s = "N_" + s;
+        return s.Length > 60 ? s[..60] : s;
     }
 
     /// <summary>
     /// Escapa texto para que no rompa el parser de Mermaid:
-    /// - Backslashes, comillas, saltos de línea y llaves.
+    /// backslashes, comillas, saltos de línea y llaves.
     /// </summary>
     private static string Esc(string? txt)
     {
         if (string.IsNullOrEmpty(txt)) return "";
         return txt
-            .Replace("\\", "\\\\")   // backslash
-            .Replace("\"", "\\\"")   // comillas
-            .Replace("\r", " ")      // CR
-            .Replace("\n", " ")      // LF
-            .Replace("{", "\\{")     // llaves
-            .Replace("}", "\\}");    // llaves
+            .Replace("\\", "\\\\")
+            .Replace("\"", "\\\"")
+            .Replace("\r", " ")
+            .Replace("\n", " ")
+            .Replace("{", "\\{")
+            .Replace("}", "\\}");
     }
 
-    /// <summary>
-    /// Construye el diagrama Mermaid (flowchart LR) en notación tipo Chen.
-    /// </summary>
-    /// <param name="s">Instantánea del esquema (tablas, columnas, FKs, tablas puente, etc.).</param>
-    /// <returns>Texto Mermaid listo para renderizar.</returns>
     public string Construir(InstantaneaEsquema s)
     {
         var sb = new StringBuilder();
+        var ocultas = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "EER_UserChoices" };
+        AgregarEncabezado(sb);
+        AgregarEntidades(sb, s, ocultas);
+        AgregarRelacionesBinarias(sb, s, ocultas);
+        AgregarRelacionesMN(sb, s, ocultas);
+        AgregarEntidadesDebiles(sb, s, ocultas);
+        return sb.ToString();
+    }
 
-        // Tablas internas que no deben dibujarse
-        var ocultas = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+    private static void AgregarEncabezado(StringBuilder sb)
     {
-        "EER_UserChoices"
-    };
-
-        // Encabezado y estilos
         sb.AppendLine("flowchart LR");
         sb.AppendLine("classDef entidad fill:#eef,stroke:#334,stroke-width:1px,rx:8,ry:8;");
         sb.AppendLine("classDef relacion fill:#ffe,stroke:#a66,stroke-width:2px;");
         sb.AppendLine("classDef atributo fill:#eef,stroke:#557;");
         sb.AppendLine("classDef clave font-weight:bold,text-decoration:underline;");
         sb.AppendLine("classDef unico stroke-dasharray:3 2;");
+    }
 
-        // -------- Entidades --------
+    private static void AgregarEntidades(StringBuilder sb, InstantaneaEsquema s, HashSet<string> ocultas)
+    {
         foreach (var t in s.Tablas)
         {
-            if (ocultas.Contains(t.Nombre)) continue; // 👈 filtra EER_UserChoices
+            if (ocultas.Contains(t.Nombre)) continue;
             if (s.TablasUnionMuchosAMuchos.Contains(t.Nombre)) continue;
 
             var entId = San(t.Nombre);
             sb.AppendLine($"  {entId}[{Esc(t.Nombre)}]:::entidad");
 
-            foreach (var c in s.Columnas.Where(x => x.Tabla == t.Nombre))
+            foreach (var c in s.Columnas)
             {
+                if (c.Tabla != t.Nombre) continue;
                 var attrId = $"{entId}__{San(c.Nombre)}";
                 sb.AppendLine($"  {attrId}(({Esc(c.Nombre)})):::atributo");
-
                 if (c.EsPk) sb.AppendLine($"  class {attrId} clave;");
                 else if (c.EsUnicoCandidato) sb.AppendLine($"  class {attrId} unico;");
-
                 sb.AppendLine($"  {attrId} --- {entId}");
             }
         }
+    }
 
-        // -------- Relaciones binarias (FKs) --------
+    private static void AgregarRelacionesBinarias(StringBuilder sb, InstantaneaEsquema s, HashSet<string> ocultas)
+    {
         int r = 0;
         foreach (var fk in s.LlavesForaneas)
         {
-            if (ocultas.Contains(fk.TablaPadre) || ocultas.Contains(fk.TablaHija)) continue; // 👈 filtra
+            if (ocultas.Contains(fk.TablaPadre) || ocultas.Contains(fk.TablaHija)) continue;
             if (s.TablasUnionMuchosAMuchos.Contains(fk.TablaHija)) continue;
 
             var relId = $"REL_{r++}_{San(fk.Nombre)}";
             sb.AppendLine($"  {relId}{{{{{Esc(fk.Nombre)}}}}}:::relacion");
             sb.AppendLine($"  {San(fk.TablaPadre)} -- \"1\" --> {relId}");
 
-            string mult = fk.HijaEsUnica
+            var mult = fk.HijaEsUnica
                 ? (fk.HijaTodasNoNulas ? "1" : "0..1")
                 : (fk.HijaTodasNoNulas ? "1..N" : "0..N");
 
-            if (fk.HijaTodasNoNulas)
-                sb.AppendLine($"  {relId} -- \"{mult}\" --> {San(fk.TablaHija)}");
-            else
-                sb.AppendLine($"  {relId} -. \"{mult}\" .-> {San(fk.TablaHija)}");
+            var flecha = fk.HijaTodasNoNulas ? "--" : "-.";
+            var cola = fk.HijaTodasNoNulas ? "-->" : ".->";
+            sb.AppendLine($"  {relId} {flecha} \"{mult}\" {cola} {San(fk.TablaHija)}");
         }
-
-        // -------- Relaciones M:N --------
-        foreach (var jt in s.TablasUnionMuchosAMuchos)
-        {
-            if (ocultas.Contains(jt)) continue; // 👈 filtra
-            var padres = s.LlavesForaneas
-                .Where(f => f.TablaHija == jt)
-                .Select(f => f.TablaPadre)
-                .Distinct()
-                .ToList();
-
-            if (padres.Count == 2)
-            {
-                var relId = $"MN_{San(jt)}";
-                sb.AppendLine($"  {relId}{{{{{Esc(jt)}}}}}:::relacion");
-
-                sb.AppendLine($"  {San(padres[0])} -- \"1..N\" --> {relId}");
-                sb.AppendLine($"  {relId} -- \"1..N\" --> {San(padres[1])}");
-
-                var fkCols = new HashSet<string>(
-                    s.LlavesForaneas.Where(f => f.TablaHija == jt)
-                        .SelectMany(f => f.ColumnasHijaCsv.Split(',').Select(x => x.Trim())),
-                    StringComparer.OrdinalIgnoreCase);
-
-                var attrsRelacion = s.Columnas.Where(c => c.Tabla == jt && !fkCols.Contains(c.Nombre));
-                foreach (var c in attrsRelacion)
-                {
-                    var aid = $"{San(jt)}__{San(c.Nombre)}";
-                    sb.AppendLine($"  {aid}(({Esc(c.Nombre)})):::atributo");
-                    if (c.EsPk) sb.AppendLine($"  class {aid} clave;");
-                    sb.AppendLine($"  {aid} --- {relId}");
-                }
-            }
-        }
-
-        foreach (var w in s.EntidadesDebiles)
-            if (!ocultas.Contains(w)) // 👈 también aquí
-                sb.AppendLine($"  %% {w} es ENTIDAD DEBIL (PK incluye FK)");
-
-        return sb.ToString();
     }
 
+    private static void AgregarRelacionesMN(StringBuilder sb, InstantaneaEsquema s, HashSet<string> ocultas)
+    {
+        foreach (var jt in s.TablasUnionMuchosAMuchos)
+        {
+            if (ocultas.Contains(jt)) continue;
+
+            var padres = new List<string>();
+            foreach (var fk in s.LlavesForaneas)
+                if (fk.TablaHija == jt && !padres.Contains(fk.TablaPadre))
+                    padres.Add(fk.TablaPadre);
+
+            if (padres.Count != 2) continue;
+
+            var relId = $"MN_{San(jt)}";
+            sb.AppendLine($"  {relId}{{{{{Esc(jt)}}}}}:::relacion");
+            sb.AppendLine($"  {San(padres[0])} -- \"1..N\" --> {relId}");
+            sb.AppendLine($"  {relId} -- \"1..N\" --> {San(padres[1])}");
+
+            var fkCols = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var fk in s.LlavesForaneas)
+            {
+                if (fk.TablaHija != jt) continue;
+                var cols = fk.ColumnasHijaCsv.Split(',', StringSplitOptions.RemoveEmptyEntries);
+                foreach (var col in cols) fkCols.Add(col.Trim());
+            }
+
+            foreach (var c in s.Columnas)
+            {
+                if (c.Tabla != jt || fkCols.Contains(c.Nombre)) continue;
+                var aid = $"{San(jt)}__{San(c.Nombre)}";
+                sb.AppendLine($"  {aid}(({Esc(c.Nombre)})):::atributo");
+                if (c.EsPk) sb.AppendLine($"  class {aid} clave;");
+                sb.AppendLine($"  {aid} --- {relId}");
+            }
+        }
+    }
+
+    private static void AgregarEntidadesDebiles(StringBuilder sb, InstantaneaEsquema s, HashSet<string> ocultas)
+    {
+        foreach (var w in s.EntidadesDebiles)
+            if (!ocultas.Contains(w))
+                sb.AppendLine($"  %% {w} es ENTIDAD DEBIL (PK incluye FK)");
+    }
 }

--- a/Services/ConstructorDiagramaRelacional.cs
+++ b/Services/ConstructorDiagramaRelacional.cs
@@ -1,20 +1,26 @@
 ﻿using System;
-using System.Linq;
 using System.Text;
-using System.Text.RegularExpressions;
 using System.Collections.Generic;
 
 public class ConstructorDiagramaRelacional
 {
-    private static readonly Regex _idBad = new(@"[^A-Za-z0-9_]", RegexOptions.Compiled);
-
     private static string San(string? id)
     {
-        var s = id ?? "X";
-        s = _idBad.Replace(s, "_");
-        if (string.IsNullOrEmpty(s) || !char.IsLetter(s[0])) s = "N_" + s;
-        if (s.Length > 60) s = s[..60];
-        return s;
+        var src = string.IsNullOrEmpty(id) ? "X" : id;
+        var sb = new StringBuilder(src.Length);
+        foreach (var ch in src)
+            sb.Append(char.IsLetterOrDigit(ch) || ch == '_' ? ch : '_');
+        var s = sb.ToString();
+        if (s.Length == 0 || !char.IsLetter(s[0])) s = "N_" + s;
+        return s.Length > 60 ? s[..60] : s;
+    }
+
+    private static string Limpiar(string t)
+    {
+        var sb = new StringBuilder(t.Length);
+        foreach (var ch in t)
+            sb.Append(char.IsLetterOrDigit(ch) || ch == '_' ? ch : '_');
+        return sb.ToString();
     }
 
     // Escapar caracteres que rompen erDiagram, incluidas comillas
@@ -41,9 +47,8 @@ public class ConstructorDiagramaRelacional
         "decimal" or "numeric" => "decimal",
         "float" => "float",
         "varchar" or "nvarchar" => "varchar",
-        _ => _idBad.Replace(t, "_") // simplifica tipos raros para Mermaid
+        _ => Limpiar(t) // simplifica tipos raros para Mermaid
     };
-
     /// Genera Mermaid erDiagram (crow’s foot) a partir de InstantaneaEsquema.
     public string Construir(InstantaneaEsquema s)
     {
@@ -51,60 +56,68 @@ public class ConstructorDiagramaRelacional
         var sb = new StringBuilder();
         sb.AppendLine("erDiagram");
 
-        // --------- Índice: columnas FK por tabla (maneja FKs compuestas) ----------
-        var fksPorTabla = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
+        var fksPorTabla = IndiceFksPorTabla(s);
+        AgregarTablas(sb, s, ocultas, fksPorTabla);
+        AgregarRelaciones(sb, s, ocultas);
+        return sb.ToString();
+    }
+
+    private static Dictionary<string, HashSet<string>> IndiceFksPorTabla(InstantaneaEsquema s)
+    {
+        var dict = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
         foreach (var fk in s.LlavesForaneas)
         {
-            if (!fksPorTabla.TryGetValue(fk.TablaHija, out var set))
+            if (!dict.TryGetValue(fk.TablaHija, out var set))
             {
                 set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-                fksPorTabla[fk.TablaHija] = set;
+                dict[fk.TablaHija] = set;
             }
-
-            foreach (var col in fk.ColumnasHijaCsv.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            var cols = fk.ColumnasHijaCsv.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            foreach (var col in cols)
                 set.Add(col);
         }
+        return dict;
+    }
 
-        // ------------------------- Tablas + columnas ------------------------------
-        foreach (var t in s.Tablas.Select(x => x.Nombre))
+    private static void AgregarTablas(StringBuilder sb, InstantaneaEsquema s, HashSet<string> ocultas, Dictionary<string, HashSet<string>> fksPorTabla)
+    {
+        foreach (var tabla in s.Tablas)
         {
+            var t = tabla.Nombre;
             if (ocultas.Contains(t)) continue;
 
-            // Hash de FKs de esta tabla (si no tiene, set vacío)
             fksPorTabla.TryGetValue(t, out var fkCols);
             fkCols ??= new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
             sb.AppendLine($"  {San(t)} {{");
-            foreach (var c in s.Columnas.Where(c => c.Tabla == t))
+            foreach (var c in s.Columnas)
             {
+                if (c.Tabla != t) continue;
                 var tipo = MapTipo(c.Tipo);
-
-                // Flags: PK / FK / UK (sin paréntesis; Mermaid los muestra como texto a la derecha)
                 var flags = new List<string>();
                 if (c.EsPk) flags.Add("PK");
                 if (fkCols.Contains(c.Nombre)) flags.Add("FK");
-                if (c.EsUnicoCandidato && !c.EsPk) flags.Add("UK"); // si ya es PK, no repito UK
-
+                if (c.EsUnicoCandidato && !c.EsPk) flags.Add("UK");
                 var flagTxt = flags.Count > 0 ? " " + string.Join(" ", flags) : "";
                 sb.AppendLine($"    {Esc(tipo)} {Esc(c.Nombre)}{flagTxt}");
             }
             sb.AppendLine("  }");
         }
+    }
 
-        // --------------------------- Relaciones (patas) ---------------------------
+    private static void AgregarRelaciones(StringBuilder sb, InstantaneaEsquema s, HashSet<string> ocultas)
+    {
         foreach (var fk in s.LlavesForaneas)
         {
             if (ocultas.Contains(fk.TablaPadre) || ocultas.Contains(fk.TablaHija)) continue;
 
-            var left = "||"; // padre: exactamente 1
-            string right = fk.HijaEsUnica
-                ? (fk.HijaTodasNoNulas ? "||" : "o|")   // 1:1 o 0..1
-                : (fk.HijaTodasNoNulas ? "|{" : "o{");  // 1:N o 0..N
+            var left = "||";
+            var right = fk.HijaEsUnica
+                ? (fk.HijaTodasNoNulas ? "||" : "o|")
+                : (fk.HijaTodasNoNulas ? "|{" : "o{");
 
             var etiqueta = Esc(fk.Nombre);
             sb.AppendLine($"  {San(fk.TablaPadre)} {left}--{right} {San(fk.TablaHija)} : \"{etiqueta}\"");
         }
-
-        return sb.ToString();
     }
 }

--- a/Services/InferenciaEER.cs
+++ b/Services/InferenciaEER.cs
@@ -1,19 +1,11 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 
 #region Modelos EER
-
-/// <summary>Estado de disyunción en la jerarquía EER.</summary>
 public enum EerDisjointness { Exclusive, Overlapping, Ambiguous }
-/// <summary>Estado de totalidad en la jerarquía EER.</summary>
 public enum EerTotalness { Total, Partial, Ambiguous }
 
-/// <summary>
-/// Jerarquía de especialización (EER) detectada:
-/// Supertipo, lista de Subtipos y heurísticas de Disyunción/Totalidad.
-/// </summary>
 public class JerarquiaEer
 {
     public string Supertipo { get; init; } = "";
@@ -22,92 +14,107 @@ public class JerarquiaEer
     public EerTotalness Totalidad { get; set; } = EerTotalness.Ambiguous;
     public string? Evidencia { get; set; }
 }
-
 #endregion
 
-/// <summary>
-/// Motor de inferencia EER: detecta jerarquías por patrón PK=FK (FK UNIQUE) y
-/// renderiza un diagrama Mermaid con etiqueta de “especialización”.
-/// </summary>
 public static class InferenciaEER
 {
-    /// <summary>
-    /// Detecta jerarquías de especialización (subtipos) por el patrón PK=FK:
-    /// la FK en la hija es única y coincide (en orden) con la PK de la hija.
-    /// </summary>
-    /// <param name="s">Instantánea del esquema con tablas, columnas y FKs agrupadas.</param>
-    /// <returns>Lista de <see cref="JerarquiaEer"/> detectadas.</returns>
     public static List<JerarquiaEer> DetectarJerarquias(InstantaneaEsquema s)
     {
-        // PK por tabla (para comparar con columnas de las FK en hija)
-        var pkPorTabla = s.Tablas.ToDictionary(
-            t => t.Nombre,
-            t => s.Columnas.Where(c => c.Tabla == t.Nombre && c.EsPk).Select(c => c.Nombre).ToList(),
-            StringComparer.OrdinalIgnoreCase);
-
-        // Candidatos a subtipo: FK única en hija y columnas FK == PK(hija)
-        var candidatos = s.LlavesForaneas.Where(fk =>
-        {
-            if (!fk.HijaEsUnica) return false;
-            if (!pkPorTabla.TryGetValue(fk.TablaHija, out var pkCols) || pkCols.Count == 0) return false;
-
-            var fkCols = fk.ColumnasHijaCsv.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
-            return pkCols.SequenceEqual(fkCols, StringComparer.OrdinalIgnoreCase);
-        }).ToList();
-
-        // Agrupar por padre → Supertipo; hijas → Subtipos
-        var grupos = candidatos.GroupBy(x => x.TablaPadre, StringComparer.OrdinalIgnoreCase);
-        var lista = new List<JerarquiaEer>();
-
-        foreach (var g in grupos)
-        {
-            var j = new JerarquiaEer { Supertipo = g.Key };
-            foreach (var fk in g) j.Subtipos.Add(fk.TablaHija);
-
-            // Heurística: discriminador NOT NULL en el supertipo → Disyunción exclusiva.
-            var disc = s.Columnas.FirstOrDefault(c =>
-                c.Tabla.Equals(j.Supertipo, StringComparison.OrdinalIgnoreCase) &&
-                (c.Nombre.Equals("Tipo", StringComparison.OrdinalIgnoreCase) ||
-                 c.Nombre.Equals("Discriminator", StringComparison.OrdinalIgnoreCase) ||
-                 c.Nombre.Equals("Categoria", StringComparison.OrdinalIgnoreCase) ||
-                 c.Nombre.Equals("Clase", StringComparison.OrdinalIgnoreCase) ||
-                 c.Nombre.Equals("Subtipo", StringComparison.OrdinalIgnoreCase)));
-
-            if (disc is not null && !disc.EsNulo)
-            {
-                j.Disyuncion = EerDisjointness.Exclusive;
-                j.Totalidad = EerTotalness.Ambiguous;
-                j.Evidencia = $"Discriminador {disc.Nombre} en {j.Supertipo} (NOT NULL).";
-            }
-            else
-            {
-                j.Disyuncion = j.Subtipos.Count > 1 ? EerDisjointness.Overlapping : EerDisjointness.Ambiguous;
-                j.Totalidad = EerTotalness.Ambiguous;
-                j.Evidencia = "Subtipos detectados por patrón PK=FK (FK UNIQUE).";
-            }
-
-            lista.Add(j);
-        }
-
-        return lista;
+        var pkPorTabla = ConstruirPkPorTabla(s);
+        var candidatos = BuscarCandidatos(s, pkPorTabla);
+        return AgruparJerarquias(candidatos, s);
     }
 
-    /// <summary>
-    /// Renderiza Mermaid (flowchart TB) para jerarquías EER con nodo “especialización”.
-    /// </summary>
+    private static Dictionary<string, List<string>> ConstruirPkPorTabla(InstantaneaEsquema s)
+    {
+        var dict = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+        foreach (var t in s.Tablas)
+        {
+            var cols = new List<string>();
+            foreach (var c in s.Columnas)
+                if (c.Tabla == t.Nombre && c.EsPk)
+                    cols.Add(c.Nombre);
+            dict[t.Nombre] = cols;
+        }
+        return dict;
+    }
+
+    private static List<InfoLlaveForanea> BuscarCandidatos(InstantaneaEsquema s, Dictionary<string, List<string>> pkPorTabla)
+    {
+        var list = new List<InfoLlaveForanea>();
+        foreach (var fk in s.LlavesForaneas)
+        {
+            if (!fk.HijaEsUnica) continue;
+            if (!pkPorTabla.TryGetValue(fk.TablaHija, out var pkCols) || pkCols.Count == 0) continue;
+            var fkCols = fk.ColumnasHijaCsv.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            if (pkCols.Count != fkCols.Length) continue;
+            bool igual = true;
+            for (int i = 0; i < pkCols.Count; i++)
+                if (!pkCols[i].Equals(fkCols[i], StringComparison.OrdinalIgnoreCase))
+                { igual = false; break; }
+            if (igual) list.Add(fk);
+        }
+        return list;
+    }
+
+    private static List<JerarquiaEer> AgruparJerarquias(List<InfoLlaveForanea> candidatos, InstantaneaEsquema s)
+    {
+        var porPadre = new Dictionary<string, List<InfoLlaveForanea>>(StringComparer.OrdinalIgnoreCase);
+        foreach (var fk in candidatos)
+        {
+            if (!porPadre.TryGetValue(fk.TablaPadre, out var list))
+            {
+                list = new List<InfoLlaveForanea>();
+                porPadre[fk.TablaPadre] = list;
+            }
+            list.Add(fk);
+        }
+
+        var resultado = new List<JerarquiaEer>();
+        foreach (var kv in porPadre)
+            resultado.Add(CrearJerarquia(kv.Key, kv.Value, s));
+        return resultado;
+    }
+
+    private static JerarquiaEer CrearJerarquia(string padre, List<InfoLlaveForanea> fks, InstantaneaEsquema s)
+    {
+        var j = new JerarquiaEer { Supertipo = padre };
+        foreach (var fk in fks) j.Subtipos.Add(fk.TablaHija);
+
+        var disc = BuscarDiscriminador(padre, s);
+        if (disc is not null && !disc.EsNulo)
+        {
+            j.Disyuncion = EerDisjointness.Exclusive;
+            j.Evidencia = $"Discriminador {disc.Nombre} en {padre} (NOT NULL).";
+        }
+        else
+        {
+            j.Disyuncion = j.Subtipos.Count > 1 ? EerDisjointness.Overlapping : EerDisjointness.Ambiguous;
+            j.Evidencia = "Subtipos detectados por patrón PK=FK (FK UNIQUE).";
+        }
+
+        j.Totalidad = EerTotalness.Ambiguous;
+        return j;
+    }
+
+    private static InfoColumna? BuscarDiscriminador(string sup, InstantaneaEsquema s)
+    {
+        foreach (var c in s.Columnas)
+        {
+            if (!c.Tabla.Equals(sup, StringComparison.OrdinalIgnoreCase)) continue;
+            var n = c.Nombre;
+            if (n.Equals("Tipo", StringComparison.OrdinalIgnoreCase) ||
+                n.Equals("Discriminator", StringComparison.OrdinalIgnoreCase) ||
+                n.Equals("Categoria", StringComparison.OrdinalIgnoreCase) ||
+                n.Equals("Clase", StringComparison.OrdinalIgnoreCase) ||
+                n.Equals("Subtipo", StringComparison.OrdinalIgnoreCase))
+                return c;
+        }
+        return null;
+    }
+
     public static string RenderMermaidEER(IReadOnlyList<JerarquiaEer> hs)
     {
-        // Sanear IDs Mermaid
-        string San(string s)
-        {
-            var x = new string(s.Select(ch => char.IsLetterOrDigit(ch) ? ch : '_').ToArray());
-            if (x.Length == 0 || !char.IsLetter(x[0])) x = "N_" + x;
-            return x.Length > 60 ? x[..60] : x;
-        }
-        // Escapar texto para Mermaid
-        string Esc(string? s) =>
-            (s ?? "").Replace("\\", "\\\\").Replace("\"", "\\\"").Replace("\r", " ").Replace("\n", " ");
-
         var sb = new StringBuilder();
         sb.AppendLine("flowchart TB");
         sb.AppendLine("classDef super fill:#e8f4ff,stroke:#2a6fb3,stroke-width:1px,rx:8,ry:8;");
@@ -116,41 +123,59 @@ public static class InferenciaEER
 
         int k = 0;
         foreach (var h in hs)
-        {
-            var tagDis = h.Disyuncion switch
-            {
-                EerDisjointness.Exclusive => "exclusive",
-                EerDisjointness.Overlapping => "overlapping",
-                _ => "ambiguous"
-            };
-            var tagTot = h.Totalidad switch
-            {
-                EerTotalness.Total => "total",
-                EerTotalness.Partial => "partial",
-                _ => "ambiguous"
-            };
-
-            var supId = San(h.Supertipo);
-            sb.AppendLine($"{supId}[\"{Esc(h.Supertipo)} ({tagDis},{tagTot})\"]:::super");
-
-            var genId = $"GEN_{k++}_{supId}";
-            sb.AppendLine($"{genId}[[especializacion]]:::note");
-            sb.AppendLine($"{genId} --> {supId}");
-
-            foreach (var sub in h.Subtipos.Distinct(StringComparer.OrdinalIgnoreCase))
-            {
-                var subId = San(sub);
-                sb.AppendLine($"{subId}(\"{Esc(sub)}\"):::sub");
-                sb.AppendLine($"{subId} -->|is a| {genId}");
-            }
-
-            if (!string.IsNullOrWhiteSpace(h.Evidencia))
-            {
-                var noteId = $"NOTE_{supId}";
-                sb.AppendLine($"{noteId}[\"{Esc(h.Evidencia)}\"]:::note");
-                sb.AppendLine($"{noteId} -.-> {supId}");
-            }
-        }
+            RenderJerarquia(sb, h, ref k);
         return sb.ToString();
+    }
+
+    private static string SanId(string s)
+    {
+        var sb = new StringBuilder();
+        foreach (var ch in s)
+            sb.Append(char.IsLetterOrDigit(ch) ? ch : '_');
+        if (sb.Length == 0 || !char.IsLetter(sb[0])) sb.Insert(0, "N_");
+        var r = sb.ToString();
+        return r.Length > 60 ? r[..60] : r;
+    }
+
+    private static string EscTxt(string? s) =>
+        (s ?? "").Replace("\\", "\\\\").Replace("\"", "\\\"").Replace("\r", " ").Replace("\n", " ");
+
+    private static void RenderJerarquia(StringBuilder sb, JerarquiaEer h, ref int k)
+    {
+        var tagDis = h.Disyuncion switch
+        {
+            EerDisjointness.Exclusive => "exclusive",
+            EerDisjointness.Overlapping => "overlapping",
+            _ => "ambiguous",
+        };
+        var tagTot = h.Totalidad switch
+        {
+            EerTotalness.Total => "total",
+            EerTotalness.Partial => "partial",
+            _ => "ambiguous",
+        };
+
+        var supId = SanId(h.Supertipo);
+        sb.AppendLine($"{supId}[\"{EscTxt(h.Supertipo)} ({tagDis},{tagTot})\"]:::super");
+
+        var genId = $"GEN_{k++}_{supId}";
+        sb.AppendLine($"{genId}[[especializacion]]:::note");
+        sb.AppendLine($"{genId} --> {supId}");
+
+        var vistos = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var sub in h.Subtipos)
+        {
+            if (!vistos.Add(sub)) continue;
+            var subId = SanId(sub);
+            sb.AppendLine($"{subId}(\"{EscTxt(sub)}\"):::sub");
+            sb.AppendLine($"{subId} -->|is a| {genId}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(h.Evidencia))
+        {
+            var noteId = $"NOTE_{supId}";
+            sb.AppendLine($"{noteId}[\"{EscTxt(h.Evidencia)}\"]:::note");
+            sb.AppendLine($"{noteId} -.-> {supId}");
+        }
     }
 }

--- a/Services/LectorEsquemaSql.cs
+++ b/Services/LectorEsquemaSql.cs
@@ -1,11 +1,9 @@
 ﻿// Models (pueden ir arriba del mismo archivo)
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Text.RegularExpressions;
 
 /// <summary>
 /// Información mínima de una tabla para el diagrama.
@@ -67,12 +65,17 @@ public class InstantaneaEsquema
 public class LectorEsquemaSql
 {
     private readonly string _cnnMaestra;
+    private readonly ILogger<LectorEsquemaSql> _logger;
 
     /// <summary>
     /// Crea el lector con una cadena de conexión "maestra" (server/credenciales),
     /// desde la cual se apuntará dinámicamente al catálogo de la BD restaurada.
     /// </summary>
-    public LectorEsquemaSql(IConfiguration cfg) => _cnnMaestra = cfg.GetConnectionString("SqlMaestra")!;
+    public LectorEsquemaSql(IConfiguration cfg, ILogger<LectorEsquemaSql> logger)
+    {
+        _cnnMaestra = cfg.GetConnectionString("SqlMaestra")!;
+        _logger = logger;
+    }
 
     /// <summary>
     /// Construye una cadena de conexión a una BD específica reutilizando servidor/credenciales de la cadena maestra.
@@ -83,37 +86,7 @@ public class LectorEsquemaSql
         return csb.ToString();
     }
 
-    /// <summary>
-    /// Lee el esquema (tablas, columnas, FKs, heurísticas) de la base indicada.
-    /// </summary>
-    /// <param name="nombreBD">Nombre de la base restaurada.</param>
-    /// <returns>Instantánea del esquema para diagrama ER/EER.</returns>
-    public async Task<InstantaneaEsquema> LeerAsync(string nombreBD)
-    {
-        var s = new InstantaneaEsquema();
-
-        using var cn = new SqlConnection(CnnDeBD(_cnnMaestra, nombreBD));
-        await cn.OpenAsync();
-
-        // =========================
-        // 1) TABLAS (excluye las del sistema)
-        // =========================
-        using (var cmd = cn.CreateCommand())
-        {
-            cmd.CommandText = "SELECT name FROM sys.tables WHERE is_ms_shipped = 0 ORDER BY name;";
-            using var rd = await cmd.ExecuteReaderAsync();
-            while (await rd.ReadAsync())
-                s.Tablas.Add(new InfoTabla(rd.GetString(0)));
-        }
-
-        // =========================
-        // 2) COLUMNAS + flags PK/UNIQUE
-        //    - pkcols: columnas que conforman la PK.
-        //    - uqcols: columnas que participan en índices únicos (no PK).
-        // =========================
-        using (var cmd = cn.CreateCommand())
-        {
-            cmd.CommandText = @"
+    private const string SqlColumnas = @"
 WITH pkcols AS (
   SELECT ic.object_id, ic.column_id
   FROM sys.key_constraints pk
@@ -139,28 +112,8 @@ JOIN sys.types   ty ON ty.user_type_id = c.user_type_id
 LEFT JOIN pkcols pk ON pk.object_id = t.object_id AND pk.column_id = c.column_id
 LEFT JOIN uqcols uq ON uq.object_id = t.object_id AND uq.column_id = c.column_id
 ORDER BY t.name, c.column_id;";
-            using var rd = await cmd.ExecuteReaderAsync();
-            while (await rd.ReadAsync())
-            {
-                s.Columnas.Add(new InfoColumna(
-                    rd.GetString(0),             // tabla
-                    rd.GetString(1),             // columna
-                    rd.GetString(2),             // tipo
-                    rd.GetBoolean(3),            // es nulo
-                    rd.GetInt32(4) == 1,         // es pk
-                    rd.GetInt32(5) == 1));       // es único (candidato)
-            }
-        }
 
-        // =========================
-        // 3) FKs agrupadas + cardinalidad y participación
-        //    - fkg: agrupa por FK (posibles multicolumna) y mantiene orden.
-        //    - uniq_hija: pares (tabla, columnas) que están bajo algún índice único.
-        //    - fk_nullable: ***FIX*** calcula si TODAS las columnas FK son NOT NULL.
-        // =========================
-        using (var cmd = cn.CreateCommand())
-        {
-            cmd.CommandText = @"
+    private const string SqlFks = @"
 WITH fkcols AS (
   SELECT fk.object_id AS fk_id, fk.name AS FK_Nombre,
          rt.name AS TablaPadre, t.name AS TablaHija,
@@ -183,7 +136,6 @@ fkg AS (
   GROUP BY fk_id
 ),
 uniq_hija AS (
-  -- Nota: i.is_unique incluye PKs; si quieres excluir PKs, agrega 'AND i.is_primary_key = 0'
   SELECT t.name AS Tabla,
          STRING_AGG(c.name, ', ') WITHIN GROUP (ORDER BY ic.key_ordinal) AS Cols
   FROM sys.indexes i
@@ -194,8 +146,6 @@ uniq_hija AS (
   GROUP BY t.name
 ),
 fk_nullable AS (
-  -- ***FIX***: queremos 1 sólo si TODAS las columnas FK son NOT NULL.
-  -- Si alguna columna de la FK es nullable -> 0.
   SELECT fkc.constraint_object_id AS fk_id,
          MIN(CASE WHEN c.is_nullable = 0 THEN 1 ELSE 0 END) AS AllNotNull
   FROM sys.foreign_key_columns fkc
@@ -213,27 +163,8 @@ SELECT g.FK_Nombre, g.TablaPadre, g.TablaHija, g.ColsPadre, g.ColsHija,
 FROM fkg g
 JOIN fk_nullable n ON n.fk_id = g.fk_id
 ORDER BY g.TablaPadre, g.TablaHija;";
-            using var rd = await cmd.ExecuteReaderAsync();
-            while (await rd.ReadAsync())
-            {
-                s.LlavesForaneas.Add(new InfoLlaveForanea(
-                    rd.GetString(0),             // nombre FK
-                    rd.GetString(1),             // tabla padre
-                    rd.GetString(2),             // tabla hija
-                    rd.GetString(3),             // cols padre csv
-                    rd.GetString(4),             // cols hija csv
-                    rd.GetInt32(5) == 1,         // hija es única
-                    rd.GetInt32(6) == 1));       // ***YA CORRECTO*** todas NOT NULL
-            }
-        }
 
-        // =========================
-        // 4) Tablas de unión M:N (heurística)
-        //    - PK de 2 columnas, al menos 2 FKs, y referencia exactamente a 2 tablas distintas.
-        // =========================
-        using (var cmd = cn.CreateCommand())
-        {
-            cmd.CommandText = @"
+    private const string SqlTablasUnion = @"
 WITH pkcols AS (
   SELECT t.object_id, t.name AS Tabla, kc.name AS PKName, COUNT(*) AS PKCols
   FROM sys.key_constraints kc
@@ -254,17 +185,8 @@ SELECT p.Tabla
 FROM pkcols p
 JOIN fkcount f ON f.object_id = p.object_id
 WHERE p.PKCols = 2 AND f.FKs >= 2 AND f.TablasReferenciadas = 2;";
-            using var rd = await cmd.ExecuteReaderAsync();
-            while (await rd.ReadAsync())
-                s.TablasUnionMuchosAMuchos.Add(rd.GetString(0));
-        }
 
-        // =========================
-        // 5) Entidades débiles (PK incluye FK)
-        // =========================
-        using (var cmd = cn.CreateCommand())
-        {
-            cmd.CommandText = @"
+    private const string SqlEntidadesDebiles = @"
 SELECT t.name AS TablaDebil
 FROM sys.tables t
 JOIN sys.key_constraints pk ON pk.parent_object_id = t.object_id AND pk.[type] = 'PK'
@@ -278,11 +200,91 @@ WHERE EXISTS (
   WHERE fkc.parent_object_id = t.object_id
     AND ic.column_id         = fkc.parent_column_id
 );";
-            using var rd = await cmd.ExecuteReaderAsync();
-            while (await rd.ReadAsync())
-                s.EntidadesDebiles.Add(rd.GetString(0));
-        }
+
+    /// <summary>
+    /// Lee el esquema (tablas, columnas, FKs, heurísticas) de la base indicada.
+    /// </summary>
+    /// <param name="nombreBD">Nombre de la base restaurada.</param>
+    /// <returns>Instantánea del esquema para diagrama ER/EER.</returns>
+    public async Task<InstantaneaEsquema> LeerAsync(string nombreBD)
+    {
+        var s = new InstantaneaEsquema();
+        using var cn = new SqlConnection(CnnDeBD(_cnnMaestra, nombreBD));
+        await cn.OpenAsync();
+
+        await LeerTablasAsync(cn, s, nombreBD);
+        await LeerColumnasAsync(cn, s);
+        await LeerLlavesForaneasAsync(cn, s);
+        await DetectarTablasUnionAsync(cn, s);
+        await DetectarEntidadesDebilesAsync(cn, s);
 
         return s;
+    }
+
+    private async Task LeerTablasAsync(SqlConnection cn, InstantaneaEsquema s, string nombreBD)
+    {
+        _logger.LogInformation("Leyendo tablas de {Base}", nombreBD);
+        using var cmd = cn.CreateCommand();
+        cmd.CommandText = "SELECT name FROM sys.tables WHERE is_ms_shipped = 0 ORDER BY name;";
+        using var rd = await cmd.ExecuteReaderAsync();
+        while (await rd.ReadAsync())
+            s.Tablas.Add(new InfoTabla(rd.GetString(0)));
+    }
+
+    private async Task LeerColumnasAsync(SqlConnection cn, InstantaneaEsquema s)
+    {
+        _logger.LogInformation("Leyendo columnas");
+        using var cmd = cn.CreateCommand();
+        cmd.CommandText = SqlColumnas;
+        using var rd = await cmd.ExecuteReaderAsync();
+        while (await rd.ReadAsync())
+        {
+            s.Columnas.Add(new InfoColumna(
+                rd.GetString(0),
+                rd.GetString(1),
+                rd.GetString(2),
+                rd.GetBoolean(3),
+                rd.GetInt32(4) == 1,
+                rd.GetInt32(5) == 1));
+        }
+    }
+
+    private async Task LeerLlavesForaneasAsync(SqlConnection cn, InstantaneaEsquema s)
+    {
+        _logger.LogInformation("Leyendo llaves foraneas");
+        using var cmd = cn.CreateCommand();
+        cmd.CommandText = SqlFks;
+        using var rd = await cmd.ExecuteReaderAsync();
+        while (await rd.ReadAsync())
+        {
+            s.LlavesForaneas.Add(new InfoLlaveForanea(
+                rd.GetString(0),
+                rd.GetString(1),
+                rd.GetString(2),
+                rd.GetString(3),
+                rd.GetString(4),
+                rd.GetInt32(5) == 1,
+                rd.GetInt32(6) == 1));
+        }
+    }
+
+    private async Task DetectarTablasUnionAsync(SqlConnection cn, InstantaneaEsquema s)
+    {
+        _logger.LogInformation("Detectando tablas M:N");
+        using var cmd = cn.CreateCommand();
+        cmd.CommandText = SqlTablasUnion;
+        using var rd = await cmd.ExecuteReaderAsync();
+        while (await rd.ReadAsync())
+            s.TablasUnionMuchosAMuchos.Add(rd.GetString(0));
+    }
+
+    private async Task DetectarEntidadesDebilesAsync(SqlConnection cn, InstantaneaEsquema s)
+    {
+        _logger.LogInformation("Detectando entidades débiles");
+        using var cmd = cn.CreateCommand();
+        cmd.CommandText = SqlEntidadesDebiles;
+        using var rd = await cmd.ExecuteReaderAsync();
+        while (await rd.ReadAsync())
+            s.EntidadesDebiles.Add(rd.GetString(0));
     }
 }

--- a/Services/ServicioRestauracionSql.cs
+++ b/Services/ServicioRestauracionSql.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Logging;
 using System.Data;
 
 /// <summary>
@@ -9,13 +10,15 @@ using System.Data;
 public class ServicioRestauracionSql
 {
     private readonly string _cnnMaestra;
+    private readonly ILogger<ServicioRestauracionSql> _logger;
 
     /// <summary>
     /// Crea el servicio leyendo la cadena de conexión "SqlMaestra" (appsettings.json / secretos).
     /// </summary>
-    public ServicioRestauracionSql(IConfiguration cfg)
+    public ServicioRestauracionSql(IConfiguration cfg, ILogger<ServicioRestauracionSql> logger)
     {
         _cnnMaestra = cfg.GetConnectionString("SqlMaestra")!;
+        _logger = logger;
     }
 
     /// <summary>
@@ -30,73 +33,84 @@ public class ServicioRestauracionSql
     /// <exception cref="Exception">Si el .bak no contiene archivos o es incompatible.</exception>
     public async Task<string> RestaurarAsync(string rutaBak, string prefijoNombre = "ER")
     {
-        // Genera un nombre único y “amigable” (sin guiones, mayúsculas).
-        var nombreBD = $"{prefijoNombre}_{Guid.NewGuid():N}".ToUpper();
-
+        var nombreBD = GenerarNombre(prefijoNombre);
         using var cn = new SqlConnection(_cnnMaestra);
         await cn.OpenAsync();
 
-        // 1) Obtener rutas por defecto (data y log) del instance
-        string rutaDatos, rutaLog;
-        using (var cmd = cn.CreateCommand())
-        {
-            cmd.CommandText = @"
+        var (rutaDatos, rutaLog) = await ObtenerRutasPorDefectoAsync(cn);
+        var archivos = await LeerArchivosLogicosAsync(cn, rutaBak);
+        var (logicoDatos, logicoLog) = SeleccionarArchivosLogicos(archivos);
+        var (fisicoDatos, fisicoLog) = ConstruirRutasFisicas(rutaDatos, rutaLog, nombreBD);
+        await RestaurarBaseAsync(cn, rutaBak, nombreBD, logicoDatos, logicoLog, fisicoDatos, fisicoLog);
+
+        return nombreBD;
+    }
+
+    private string GenerarNombre(string prefijo) => $"{prefijo}_{Guid.NewGuid():N}".ToUpper();
+
+    private static async Task<(string datos, string log)> ObtenerRutasPorDefectoAsync(SqlConnection cn)
+    {
+        using var cmd = cn.CreateCommand();
+        cmd.CommandText = @"
 SELECT CAST(SERVERPROPERTY('InstanceDefaultDataPath') AS nvarchar(4000)),
        CAST(SERVERPROPERTY('InstanceDefaultLogPath')  AS nvarchar(4000));";
-            using var rd = await cmd.ExecuteReaderAsync();
-            rd.Read(); // serverproperty devuelve una fila
-            rutaDatos = rd.GetString(0);
-            rutaLog = rd.GetString(1);
-        }
+        using var rd = await cmd.ExecuteReaderAsync();
+        rd.Read();
+        return (rd.GetString(0), rd.GetString(1));
+    }
 
-        // 2) Leer nombres lógicos de los archivos dentro del .bak
+    private static async Task<List<(string Logico, string Tipo)>> LeerArchivosLogicosAsync(SqlConnection cn, string rutaBak)
+    {
         var archivos = new List<(string Logico, string Tipo)>();
-        using (var cmd = cn.CreateCommand())
-        {
-            cmd.CommandText = "RESTORE FILELISTONLY FROM DISK = @p";
-            cmd.Parameters.Add(new SqlParameter("@p", SqlDbType.NVarChar, 4000) { Value = rutaBak });
-            using var rd = await cmd.ExecuteReaderAsync();
-            while (await rd.ReadAsync())
-            {
-                // Type: 'D' = data, 'L' = log (puede haber múltiples).
-                archivos.Add((rd["LogicalName"].ToString()!, rd["Type"].ToString()!));
-            }
-        }
+        using var cmd = cn.CreateCommand();
+        cmd.CommandText = "RESTORE FILELISTONLY FROM DISK = @p";
+        cmd.Parameters.Add(new SqlParameter("@p", SqlDbType.NVarChar, 4000) { Value = rutaBak });
+        using var rd = await cmd.ExecuteReaderAsync();
+        while (await rd.ReadAsync())
+            archivos.Add((rd["LogicalName"].ToString()!, rd["Type"].ToString()!));
         if (archivos.Count == 0)
             throw new Exception("El archivo .bak no contiene archivos o es incompatible.");
+        return archivos;
+    }
 
-        // Seleccionar un archivo lógico de datos y uno de log (asumiendo estructura típica 1D/1L)
+    private static (string datos, string log) SeleccionarArchivosLogicos(List<(string Logico, string Tipo)> archivos)
+    {
         var logicoDatos = archivos.First(a => a.Tipo == "D").Logico;
         var logicoLog = archivos.First(a => a.Tipo == "L").Logico;
+        return (logicoDatos, logicoLog);
+    }
 
-        // 3) Construir rutas físicas destino (.mdf/.ldf) en las carpetas por defecto del instance
+    private static (string datos, string log) ConstruirRutasFisicas(string rutaDatos, string rutaLog, string nombreBD)
+    {
         var fisicoDatos = Path.Combine(rutaDatos, $"{nombreBD}.mdf");
         var fisicoLog = Path.Combine(rutaLog, $"{nombreBD}_log.ldf");
+        return (fisicoDatos, fisicoLog);
+    }
 
-        // 4) Restaurar la base con MOVE + REPLACE + RECOVERY
-        using (var cmd = cn.CreateCommand())
-        {
-            // Para restores grandes, sin límite de tiempo
-            cmd.CommandTimeout = 0;
-
-            // Nota: Se parametriza el DISK y los nombres lógicos/físicos.
-            // Los identificadores (nombre de BD) se insertan en el T-SQL (no parametrizable como identificador),
-            // pero el nombre lo generamos nosotros, no proviene del usuario.
-            cmd.CommandText = @"
+    private async Task RestaurarBaseAsync(
+        SqlConnection cn,
+        string rutaBak,
+        string nombreBD,
+        string logicoDatos,
+        string logicoLog,
+        string fisicoDatos,
+        string fisicoLog)
+    {
+        using var cmd = cn.CreateCommand();
+        cmd.CommandTimeout = 0;
+        cmd.CommandText = @"
 RESTORE DATABASE [" + nombreBD + @"] FROM DISK = @p
 WITH MOVE @ld TO @d,
      MOVE @ll TO @l,
      REPLACE, RECOVERY, STATS = 5;";
-            cmd.Parameters.AddWithValue("@p", rutaBak);
-            cmd.Parameters.AddWithValue("@ld", logicoDatos);
-            cmd.Parameters.AddWithValue("@ll", logicoLog);
-            cmd.Parameters.AddWithValue("@d", fisicoDatos);
-            cmd.Parameters.AddWithValue("@l", fisicoLog);
+        cmd.Parameters.AddWithValue("@p", rutaBak);
+        cmd.Parameters.AddWithValue("@ld", logicoDatos);
+        cmd.Parameters.AddWithValue("@ll", logicoLog);
+        cmd.Parameters.AddWithValue("@d", fisicoDatos);
+        cmd.Parameters.AddWithValue("@l", fisicoLog);
 
-            await cmd.ExecuteNonQueryAsync();
-        }
-
-        return nombreBD;
+        _logger.LogInformation("Restaurando base de datos {Nombre}", nombreBD);
+        await cmd.ExecuteNonQueryAsync();
     }
 
     /// <summary>
@@ -120,6 +134,7 @@ BEGIN
 END";
         cmd.Parameters.AddWithValue("@db", nombreBD);
 
+        _logger.LogInformation("Eliminando base de datos {Nombre}", nombreBD);
         await cmd.ExecuteNonQueryAsync();
     }
 }


### PR DESCRIPTION
## Summary
- simplify SQL restore service with focused helpers and logging
- break schema reader into smaller logged steps
- rewrite Mermaid builders without regex or heavy LINQ
- streamline EER inference and relational diagram generation

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3bae087a08330bf670eeb030849cc