### PR TITLE
Simplify diagram generation and schema reading

### DIFF
--- a/Controllers/DiagramaErController.cs
+++ b/Controllers/DiagramaErController.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.AspNetCore.Mvc;
-using Microsoft.Data.SqlClient;
 using System.Linq;
 
 #region Controlador: Diagrama ER / EER
@@ -95,11 +94,7 @@ public class DiagramaErController : Controller
             nombreBD = await _restaurador.RestaurarAsync(rutaBak, "ER");
 
             // 2) Leer el esquema de la BD restaurada (tablas, columnas, PKs, FKs...).
-            var snap = await _lector.LeerAsync(nombreBD);
-
-            // 2.b) Construir cadena de conexión hacia la BD restaurada.
-            //     (Se usa para leer/guardar elecciones EER en esa misma BD).
-            var cnnRestaurada = EERChoicesRestored.BuildCnnToRestoredDb(_cfg, nombreBD);
+            var snap = _lector.Leer(nombreBD);
 
             // 3) ER (Chen): generar Mermaid del modelo relacional.
             ViewBag.NombreBD = nombreBD;
@@ -107,25 +102,7 @@ public class DiagramaErController : Controller
 
             // 4) EER: detectar jerarquías de subtipos mediante heurística PK=FK (FK UNIQUE).
             var jerarquias = InferenciaEER.DetectarJerarquias(snap);
-
-            // 4.b) Aplicar elecciones guardadas previamente (si existen) desde la BD restaurada.
-            var choices = await EERChoicesRestored.LoadChoicesAsync(cnnRestaurada);
-            foreach (var j in jerarquias)
-            {
-                var subsCsv = string.Join(",", j.Subtipos.OrderBy(x => x, StringComparer.OrdinalIgnoreCase));
-                var c = choices.FirstOrDefault(x =>
-                    x.sup.Equals(j.Supertipo, StringComparison.OrdinalIgnoreCase) &&
-                    x.subs.Equals(subsCsv, StringComparison.OrdinalIgnoreCase));
-
-                if (!string.IsNullOrEmpty(c.sup))
-                {
-                    j.Disyuncion = c.dis.Equals("Exclusive", StringComparison.OrdinalIgnoreCase)
-                        ? EerDisjointness.Exclusive : EerDisjointness.Overlapping;
-                    j.Totalidad = c.tot.Equals("Total", StringComparison.OrdinalIgnoreCase)
-                        ? EerTotalness.Total : EerTotalness.Partial;
-                    j.Evidencia = "Elección del usuario aplicada.";
-                }
-            }
+            await AplicarEleccionesAsync(nombreBD, jerarquias);
 
             // 4.c) Render EER en Mermaid (con etiqueta "especializacion").
             ViewBag.MermaidEER = InferenciaEER.RenderMermaidEER(jerarquias);
@@ -170,6 +147,32 @@ public class DiagramaErController : Controller
     }
 
     /// <summary>
+    /// Aplica elecciones guardadas de disyunción/totalidad a las jerarquías detectadas.
+    /// </summary>
+    private async Task AplicarEleccionesAsync(string nombreBD, List<JerarquiaEer> jerarquias)
+    {
+        var cnnRestaurada = EERChoicesRestored.BuildCnnToRestoredDb(_cfg, nombreBD);
+        var choices = await EERChoicesRestored.LoadChoicesAsync(cnnRestaurada);
+
+        foreach (var j in jerarquias)
+        {
+            var subsCsv = string.Join(",", j.Subtipos.OrderBy(x => x, StringComparer.OrdinalIgnoreCase));
+            var c = choices.FirstOrDefault(x =>
+                x.sup.Equals(j.Supertipo, StringComparison.OrdinalIgnoreCase) &&
+                x.subs.Equals(subsCsv, StringComparison.OrdinalIgnoreCase));
+
+            if (!string.IsNullOrEmpty(c.sup))
+            {
+                j.Disyuncion = c.dis.Equals("Exclusive", StringComparison.OrdinalIgnoreCase)
+                    ? EerDisjointness.Exclusive : EerDisjointness.Overlapping;
+                j.Totalidad = c.tot.Equals("Total", StringComparison.OrdinalIgnoreCase)
+                    ? EerTotalness.Total : EerTotalness.Partial;
+                j.Evidencia = "Elección del usuario aplicada.";
+            }
+        }
+    }
+
+    /// <summary>
     /// Guarda las elecciones del usuario para Disyunción/Totalidad de cada jerarquía EER
     /// directamente en la BD restaurada y re-renderiza los diagramas.
     /// </summary>
@@ -192,30 +195,13 @@ public class DiagramaErController : Controller
             await EERChoicesRestored.SaveChoicesAsync(cnnRestaurada, Disyuncion, Totalidad, SubtypesCsv);
 
             // 2) Releer esquema y reconstruir diagramas (ER + EER) tras aplicar elecciones.
-            var snap = await _lector.LeerAsync(NombreBD);
+            var snap = _lector.Leer(NombreBD);
 
             ViewBag.NombreBD = NombreBD;
             ViewBag.Mermaid = _constructor.Construir(snap);
 
             var jerarquias = InferenciaEER.DetectarJerarquias(snap);
-
-            var choices = await EERChoicesRestored.LoadChoicesAsync(cnnRestaurada);
-            foreach (var j in jerarquias)
-            {
-                var subsCsv = string.Join(",", j.Subtipos.OrderBy(x => x, StringComparer.OrdinalIgnoreCase));
-                var c = choices.FirstOrDefault(x =>
-                    x.sup.Equals(j.Supertipo, StringComparison.OrdinalIgnoreCase) &&
-                    x.subs.Equals(subsCsv, StringComparison.OrdinalIgnoreCase));
-
-                if (!string.IsNullOrEmpty(c.sup))
-                {
-                    j.Disyuncion = c.dis.Equals("Exclusive", StringComparison.OrdinalIgnoreCase)
-                        ? EerDisjointness.Exclusive : EerDisjointness.Overlapping;
-                    j.Totalidad = c.tot.Equals("Total", StringComparison.OrdinalIgnoreCase)
-                        ? EerTotalness.Total : EerTotalness.Partial;
-                    j.Evidencia = "Elección del usuario aplicada.";
-                }
-            }
+            await AplicarEleccionesAsync(NombreBD, jerarquias);
 
             ViewBag.MermaidEER = InferenciaEER.RenderMermaidEER(jerarquias);
 

--- a/Controllers/RelacionalController.cs
+++ b/Controllers/RelacionalController.cs
@@ -18,7 +18,7 @@ public class RelacionalController : Controller
     /// /Relacional?nombreBD=ER_XXXXXXXX
     /// </summary>
     [HttpGet]
-    public async Task<IActionResult> ModeloR(string nombreBD)
+    public IActionResult ModeloR(string nombreBD)
     {
         if (string.IsNullOrWhiteSpace(nombreBD))
         {
@@ -28,7 +28,7 @@ public class RelacionalController : Controller
 
         try
         {
-            var snap = await _lector.LeerAsync(nombreBD);
+            var snap = _lector.Leer(nombreBD);
             ViewBag.NombreBD = nombreBD;
             ViewBag.MermaidRel = _constructorRel.Construir(snap);
             return View();

--- a/Services/ConstructorDiagramaChen.cs
+++ b/Services/ConstructorDiagramaChen.cs
@@ -1,53 +1,14 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Text.RegularExpressions;
 
 /// <summary>
 /// Construye un diagrama ER en notación Chen usando sintaxis de Mermaid (flowchart),
 /// a partir de una instantánea del esquema (tablas, columnas, FKs, etc.).
-/// - Pinta entidades (cuadros), atributos (óvalos) y relaciones (rombos).
-/// - Dibuja cardinalidades 1, 0..1, 1..N, 0..N según la unicidad y nulabilidad de las FKs.
-/// - Trata tablas puente (M:N) como relaciones con atributos.
 /// </summary>
 public class ConstructorDiagramaChen
 {
-    // Regex para sanear IDs de nodos en Mermaid (solo letras, números y guion bajo).
-    private static readonly Regex _idBad = new(@"[^A-Za-z0-9_]", RegexOptions.Compiled);
-
-    /// <summary>
-    /// Sanea un identificador para que sea válido en Mermaid:
-    /// - Reemplaza caracteres no permitidos por "_".
-    /// - Si no inicia con letra, antepone "N_".
-    /// - Limita a 60 caracteres (Mermaid puede romper con IDs larguísimos).
-    /// </summary>
-    private static string San(string? id)
-    {
-        var s = id ?? "X";
-        s = _idBad.Replace(s, "_");
-        if (string.IsNullOrEmpty(s) || !char.IsLetter(s[0]))
-            s = "N_" + s;
-        if (s.Length > 60) s = s[..60];
-        return s;
-    }
-
-    /// <summary>
-    /// Escapa texto para que no rompa el parser de Mermaid:
-    /// - Backslashes, comillas, saltos de línea y llaves.
-    /// </summary>
-    private static string Esc(string? txt)
-    {
-        if (string.IsNullOrEmpty(txt)) return "";
-        return txt
-            .Replace("\\", "\\\\")   // backslash
-            .Replace("\"", "\\\"")   // comillas
-            .Replace("\r", " ")      // CR
-            .Replace("\n", " ")      // LF
-            .Replace("{", "\\{")     // llaves
-            .Replace("}", "\\}");    // llaves
-    }
-
     /// <summary>
     /// Construye el diagrama Mermaid (flowchart LR) en notación tipo Chen.
     /// </summary>
@@ -59,9 +20,9 @@ public class ConstructorDiagramaChen
 
         // Tablas internas que no deben dibujarse
         var ocultas = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
-    {
-        "EER_UserChoices"
-    };
+        {
+            "EER_UserChoices",
+        };
 
         // Encabezado y estilos
         sb.AppendLine("flowchart LR");
@@ -71,19 +32,31 @@ public class ConstructorDiagramaChen
         sb.AppendLine("classDef clave font-weight:bold,text-decoration:underline;");
         sb.AppendLine("classDef unico stroke-dasharray:3 2;");
 
-        // -------- Entidades --------
+        RenderEntidades(sb, s, ocultas);
+        RenderRelacionesBinarias(sb, s, ocultas);
+        RenderRelacionesMN(sb, s, ocultas);
+        RenderEntidadesDebiles(sb, s, ocultas);
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Pinta las entidades y sus atributos a partir de las tablas.
+    /// </summary>
+    private static void RenderEntidades(StringBuilder sb, InstantaneaEsquema s, HashSet<string> ocultas)
+    {
         foreach (var t in s.Tablas)
         {
-            if (ocultas.Contains(t.Nombre)) continue; // 👈 filtra EER_UserChoices
+            if (ocultas.Contains(t.Nombre)) continue;
             if (s.TablasUnionMuchosAMuchos.Contains(t.Nombre)) continue;
 
-            var entId = San(t.Nombre);
-            sb.AppendLine($"  {entId}[{Esc(t.Nombre)}]:::entidad");
+            var entId = MermaidUtils.SanitizeId(t.Nombre);
+            sb.AppendLine($"  {entId}[{MermaidUtils.EscapeText(t.Nombre)}]:::entidad");
 
             foreach (var c in s.Columnas.Where(x => x.Tabla == t.Nombre))
             {
-                var attrId = $"{entId}__{San(c.Nombre)}";
-                sb.AppendLine($"  {attrId}(({Esc(c.Nombre)})):::atributo");
+                var attrId = $"{entId}__{MermaidUtils.SanitizeId(c.Nombre)}";
+                sb.AppendLine($"  {attrId}(({MermaidUtils.EscapeText(c.Nombre)})):::atributo");
 
                 if (c.EsPk) sb.AppendLine($"  class {attrId} clave;");
                 else if (c.EsUnicoCandidato) sb.AppendLine($"  class {attrId} unico;");
@@ -91,32 +64,43 @@ public class ConstructorDiagramaChen
                 sb.AppendLine($"  {attrId} --- {entId}");
             }
         }
+    }
 
-        // -------- Relaciones binarias (FKs) --------
+    /// <summary>
+    /// Dibuja las relaciones binarias basadas en llaves foráneas.
+    /// </summary>
+    private static void RenderRelacionesBinarias(StringBuilder sb, InstantaneaEsquema s, HashSet<string> ocultas)
+    {
         int r = 0;
         foreach (var fk in s.LlavesForaneas)
         {
-            if (ocultas.Contains(fk.TablaPadre) || ocultas.Contains(fk.TablaHija)) continue; // 👈 filtra
+            if (ocultas.Contains(fk.TablaPadre) || ocultas.Contains(fk.TablaHija)) continue;
             if (s.TablasUnionMuchosAMuchos.Contains(fk.TablaHija)) continue;
 
-            var relId = $"REL_{r++}_{San(fk.Nombre)}";
-            sb.AppendLine($"  {relId}{{{{{Esc(fk.Nombre)}}}}}:::relacion");
-            sb.AppendLine($"  {San(fk.TablaPadre)} -- \"1\" --> {relId}");
+            var relId = $"REL_{r++}_{MermaidUtils.SanitizeId(fk.Nombre)}";
+            sb.AppendLine($"  {relId}{{{{{MermaidUtils.EscapeText(fk.Nombre)}}}}}:::relacion");
+            sb.AppendLine($"  {MermaidUtils.SanitizeId(fk.TablaPadre)} -- \"1\" --> {relId}");
 
             string mult = fk.HijaEsUnica
                 ? (fk.HijaTodasNoNulas ? "1" : "0..1")
                 : (fk.HijaTodasNoNulas ? "1..N" : "0..N");
 
             if (fk.HijaTodasNoNulas)
-                sb.AppendLine($"  {relId} -- \"{mult}\" --> {San(fk.TablaHija)}");
+                sb.AppendLine($"  {relId} -- \"{mult}\" --> {MermaidUtils.SanitizeId(fk.TablaHija)}");
             else
-                sb.AppendLine($"  {relId} -. \"{mult}\" .-> {San(fk.TablaHija)}");
+                sb.AppendLine($"  {relId} -. \"{mult}\" .-> {MermaidUtils.SanitizeId(fk.TablaHija)}");
         }
+    }
 
-        // -------- Relaciones M:N --------
+    /// <summary>
+    /// Representa las relaciones muchos a muchos a partir de tablas puente.
+    /// </summary>
+    private static void RenderRelacionesMN(StringBuilder sb, InstantaneaEsquema s, HashSet<string> ocultas)
+    {
         foreach (var jt in s.TablasUnionMuchosAMuchos)
         {
-            if (ocultas.Contains(jt)) continue; // 👈 filtra
+            if (ocultas.Contains(jt)) continue;
+
             var padres = s.LlavesForaneas
                 .Where(f => f.TablaHija == jt)
                 .Select(f => f.TablaPadre)
@@ -125,11 +109,11 @@ public class ConstructorDiagramaChen
 
             if (padres.Count == 2)
             {
-                var relId = $"MN_{San(jt)}";
-                sb.AppendLine($"  {relId}{{{{{Esc(jt)}}}}}:::relacion");
+                var relId = $"MN_{MermaidUtils.SanitizeId(jt)}";
+                sb.AppendLine($"  {relId}{{{{{MermaidUtils.EscapeText(jt)}}}}}:::relacion");
 
-                sb.AppendLine($"  {San(padres[0])} -- \"1..N\" --> {relId}");
-                sb.AppendLine($"  {relId} -- \"1..N\" --> {San(padres[1])}");
+                sb.AppendLine($"  {MermaidUtils.SanitizeId(padres[0])} -- \"1..N\" --> {relId}");
+                sb.AppendLine($"  {relId} -- \"1..N\" --> {MermaidUtils.SanitizeId(padres[1])}");
 
                 var fkCols = new HashSet<string>(
                     s.LlavesForaneas.Where(f => f.TablaHija == jt)
@@ -139,19 +123,22 @@ public class ConstructorDiagramaChen
                 var attrsRelacion = s.Columnas.Where(c => c.Tabla == jt && !fkCols.Contains(c.Nombre));
                 foreach (var c in attrsRelacion)
                 {
-                    var aid = $"{San(jt)}__{San(c.Nombre)}";
-                    sb.AppendLine($"  {aid}(({Esc(c.Nombre)})):::atributo");
+                    var aid = $"{MermaidUtils.SanitizeId(jt)}__{MermaidUtils.SanitizeId(c.Nombre)}";
+                    sb.AppendLine($"  {aid}(({MermaidUtils.EscapeText(c.Nombre)})):::atributo");
                     if (c.EsPk) sb.AppendLine($"  class {aid} clave;");
                     sb.AppendLine($"  {aid} --- {relId}");
                 }
             }
         }
-
-        foreach (var w in s.EntidadesDebiles)
-            if (!ocultas.Contains(w)) // 👈 también aquí
-                sb.AppendLine($"  %% {w} es ENTIDAD DEBIL (PK incluye FK)");
-
-        return sb.ToString();
     }
 
+    /// <summary>
+    /// Anota en el diagrama las entidades débiles detectadas.
+    /// </summary>
+    private static void RenderEntidadesDebiles(StringBuilder sb, InstantaneaEsquema s, HashSet<string> ocultas)
+    {
+        foreach (var w in s.EntidadesDebiles)
+            if (!ocultas.Contains(w))
+                sb.AppendLine($"  %% {w} es ENTIDAD DEBIL (PK incluye FK)");
+    }
 }

--- a/Services/ConstructorDiagramaRelacional.cs
+++ b/Services/ConstructorDiagramaRelacional.cs
@@ -8,28 +8,6 @@ public class ConstructorDiagramaRelacional
 {
     private static readonly Regex _idBad = new(@"[^A-Za-z0-9_]", RegexOptions.Compiled);
 
-    private static string San(string? id)
-    {
-        var s = id ?? "X";
-        s = _idBad.Replace(s, "_");
-        if (string.IsNullOrEmpty(s) || !char.IsLetter(s[0])) s = "N_" + s;
-        if (s.Length > 60) s = s[..60];
-        return s;
-    }
-
-    // Escapar caracteres que rompen erDiagram, incluidas comillas
-    private static string Esc(string? txt)
-    {
-        if (string.IsNullOrEmpty(txt)) return "";
-        return txt.Replace("\r", " ")
-                  .Replace("\n", " ")
-                  .Replace("\"", "&quot;")
-                  .Replace("<", "&lt;")
-                  .Replace(">", "&gt;")
-                  .Replace("{", "\\{").Replace("}", "\\}")
-                  .Replace("[", "&#91;").Replace("]", "&#93;");
-    }
-
     private static string MapTipo(string t) => t switch
     {
         "int" => "int",
@@ -74,7 +52,7 @@ public class ConstructorDiagramaRelacional
             fksPorTabla.TryGetValue(t, out var fkCols);
             fkCols ??= new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-            sb.AppendLine($"  {San(t)} {{");
+            sb.AppendLine($"  {MermaidUtils.SanitizeId(t)} {{");
             foreach (var c in s.Columnas.Where(c => c.Tabla == t))
             {
                 var tipo = MapTipo(c.Tipo);
@@ -86,7 +64,7 @@ public class ConstructorDiagramaRelacional
                 if (c.EsUnicoCandidato && !c.EsPk) flags.Add("UK"); // si ya es PK, no repito UK
 
                 var flagTxt = flags.Count > 0 ? " " + string.Join(" ", flags) : "";
-                sb.AppendLine($"    {Esc(tipo)} {Esc(c.Nombre)}{flagTxt}");
+                sb.AppendLine($"    {MermaidUtils.EscapeText(tipo)} {MermaidUtils.EscapeText(c.Nombre)}{flagTxt}");
             }
             sb.AppendLine("  }");
         }
@@ -101,8 +79,8 @@ public class ConstructorDiagramaRelacional
                 ? (fk.HijaTodasNoNulas ? "||" : "o|")   // 1:1 o 0..1
                 : (fk.HijaTodasNoNulas ? "|{" : "o{");  // 1:N o 0..N
 
-            var etiqueta = Esc(fk.Nombre);
-            sb.AppendLine($"  {San(fk.TablaPadre)} {left}--{right} {San(fk.TablaHija)} : \"{etiqueta}\"");
+            var etiqueta = MermaidUtils.EscapeText(fk.Nombre);
+            sb.AppendLine($"  {MermaidUtils.SanitizeId(fk.TablaPadre)} {left}--{right} {MermaidUtils.SanitizeId(fk.TablaHija)} : \"{etiqueta}\"");
         }
 
         return sb.ToString();

--- a/Services/InferenciaEER.cs
+++ b/Services/InferenciaEER.cs
@@ -97,17 +97,6 @@ public static class InferenciaEER
     /// </summary>
     public static string RenderMermaidEER(IReadOnlyList<JerarquiaEer> hs)
     {
-        // Sanear IDs Mermaid
-        string San(string s)
-        {
-            var x = new string(s.Select(ch => char.IsLetterOrDigit(ch) ? ch : '_').ToArray());
-            if (x.Length == 0 || !char.IsLetter(x[0])) x = "N_" + x;
-            return x.Length > 60 ? x[..60] : x;
-        }
-        // Escapar texto para Mermaid
-        string Esc(string? s) =>
-            (s ?? "").Replace("\\", "\\\\").Replace("\"", "\\\"").Replace("\r", " ").Replace("\n", " ");
-
         var sb = new StringBuilder();
         sb.AppendLine("flowchart TB");
         sb.AppendLine("classDef super fill:#e8f4ff,stroke:#2a6fb3,stroke-width:1px,rx:8,ry:8;");
@@ -130,8 +119,8 @@ public static class InferenciaEER
                 _ => "ambiguous"
             };
 
-            var supId = San(h.Supertipo);
-            sb.AppendLine($"{supId}[\"{Esc(h.Supertipo)} ({tagDis},{tagTot})\"]:::super");
+            var supId = MermaidUtils.SanitizeId(h.Supertipo);
+            sb.AppendLine($"{supId}[\"{MermaidUtils.EscapeText(h.Supertipo)} ({tagDis},{tagTot})\"]:::super");
 
             var genId = $"GEN_{k++}_{supId}";
             sb.AppendLine($"{genId}[[especializacion]]:::note");
@@ -139,15 +128,15 @@ public static class InferenciaEER
 
             foreach (var sub in h.Subtipos.Distinct(StringComparer.OrdinalIgnoreCase))
             {
-                var subId = San(sub);
-                sb.AppendLine($"{subId}(\"{Esc(sub)}\"):::sub");
+                var subId = MermaidUtils.SanitizeId(sub);
+                sb.AppendLine($"{subId}(\"{MermaidUtils.EscapeText(sub)}\"):::sub");
                 sb.AppendLine($"{subId} -->|is a| {genId}");
             }
 
             if (!string.IsNullOrWhiteSpace(h.Evidencia))
             {
                 var noteId = $"NOTE_{supId}";
-                sb.AppendLine($"{noteId}[\"{Esc(h.Evidencia)}\"]:::note");
+                sb.AppendLine($"{noteId}[\"{MermaidUtils.EscapeText(h.Evidencia)}\"]:::note");
                 sb.AppendLine($"{noteId} -.-> {supId}");
             }
         }

--- a/Services/LectorEsquemaSql.cs
+++ b/Services/LectorEsquemaSql.cs
@@ -80,7 +80,7 @@ public class LectorEsquemaSql
     /// </summary>
     /// <param name="nombreBD">Nombre de la base restaurada.</param>
     /// <returns>Instantánea del esquema para diagrama ER/EER.</returns>
-    public Task<InstantaneaEsquema> LeerAsync(string nombreBD)
+    public InstantaneaEsquema Leer(string nombreBD)
     {
         var s = new InstantaneaEsquema();
 
@@ -96,16 +96,20 @@ public class LectorEsquemaSql
 
             s.Tablas.Add(new InfoTabla(t.Name));
 
+            // Columnas marcadas como únicas (índices únicos no PK)
             var uniqueCols = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             foreach (SmoIndex idx in t.Indexes)
-            {
                 if (idx.IsUnique && idx.IndexKeyType != IndexKeyType.DriPrimaryKey)
-                {
                     foreach (SmoIndexedColumn ic in idx.IndexedColumns)
                         uniqueCols.Add(ic.Name);
-                }
-            }
 
+            // Información de PK para heurísticas posteriores
+            var pk = t.Indexes.Cast<SmoIndex>().FirstOrDefault(i => i.IndexKeyType == IndexKeyType.DriPrimaryKey);
+            var pkCols = pk == null
+                ? new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+                : new HashSet<string>(pk.IndexedColumns.Cast<SmoIndexedColumn>().Select(ic => ic.Name), StringComparer.OrdinalIgnoreCase);
+
+            // Registro de columnas con flags PK/UK/Null
             foreach (Column col in t.Columns)
             {
                 s.Columnas.Add(new InfoColumna(
@@ -117,14 +121,23 @@ public class LectorEsquemaSql
                     uniqueCols.Contains(col.Name)));
             }
 
+            int fkCount = 0;
+            var distinctRef = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            bool fkInPk = false;
+
+            // Llaves foráneas y cardinalidad/participación
             foreach (ForeignKey fk in t.ForeignKeys)
             {
+                fkCount++;
+                distinctRef.Add(fk.ReferencedTable);
+
                 var colsPadre = new List<string>();
                 var colsHija = new List<string>();
                 foreach (ForeignKeyColumn fkc in fk.Columns)
                 {
                     colsPadre.Add(fkc.ReferencedColumn);
                     colsHija.Add(fkc.Name);
+                    if (pkCols.Contains(fkc.Name)) fkInPk = true; // heurística de entidad débil
                 }
 
                 bool hijaUnica = t.Indexes.Cast<SmoIndex>().Any(i =>
@@ -143,39 +156,16 @@ public class LectorEsquemaSql
                     hijaUnica,
                     allNotNull));
             }
-        }
 
-        foreach (Table t in db.Tables)
-        {
-            if (t.IsSystemObject)
-                continue;
-
-            var pk = t.Indexes.Cast<SmoIndex>().FirstOrDefault(i => i.IndexKeyType == IndexKeyType.DriPrimaryKey);
-            int pkCols = pk?.IndexedColumns.Count ?? 0;
-            int fkCount = t.ForeignKeys.Count;
-            int distinctRef = t.ForeignKeys.Cast<ForeignKey>().Select(f => f.ReferencedTable).Distinct(StringComparer.OrdinalIgnoreCase).Count();
-
-            if (pkCols == 2 && fkCount >= 2 && distinctRef == 2)
+            // Heurística: tabla puente M:N (PK con 2 columnas, 2 FKs a tablas distintas)
+            if (pkCols.Count == 2 && fkCount >= 2 && distinctRef.Count == 2)
                 s.TablasUnionMuchosAMuchos.Add(t.Name);
-        }
 
-        foreach (Table t in db.Tables)
-        {
-            if (t.IsSystemObject)
-                continue;
-
-            var pk = t.Indexes.Cast<SmoIndex>().FirstOrDefault(i => i.IndexKeyType == IndexKeyType.DriPrimaryKey);
-            if (pk == null)
-                continue;
-
-            var pkCols = new HashSet<string>(pk.IndexedColumns.Cast<SmoIndexedColumn>().Select(ic => ic.Name), StringComparer.OrdinalIgnoreCase);
-            bool fkInPk = t.ForeignKeys.Cast<ForeignKey>().Any(fk =>
-                fk.Columns.Cast<ForeignKeyColumn>().Any(fkc => pkCols.Contains(fkc.Name)));
-
+            // Heurística: entidad débil (alguna FK forma parte de la PK)
             if (fkInPk)
                 s.EntidadesDebiles.Add(t.Name);
         }
 
-        return Task.FromResult(s);
+        return s;
     }
 }

--- a/Services/MermaidUtils.cs
+++ b/Services/MermaidUtils.cs
@@ -1,0 +1,45 @@
+using System.Text.RegularExpressions;
+
+/// <summary>
+/// Utilidades compartidas para generar diagramas Mermaid.
+/// </summary>
+public static class MermaidUtils
+{
+    // Regex para sanear identificadores Mermaid.
+    private static readonly Regex _idBad = new("[^A-Za-z0-9_]", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Sanitiza un identificador para que sea válido en Mermaid.
+    /// Reemplaza caracteres no permitidos, asegura inicio con letra
+    /// y limita su longitud a 60 caracteres.
+    /// </summary>
+    public static string SanitizeId(string? id)
+    {
+        var s = id ?? "X";
+        s = _idBad.Replace(s, "_");
+        if (string.IsNullOrEmpty(s) || !char.IsLetter(s[0]))
+            s = "N_" + s;
+        if (s.Length > 60) s = s[..60];
+        return s;
+    }
+
+    /// <summary>
+    /// Escapa texto para que no rompa el parser de Mermaid.
+    /// Maneja caracteres problemáticos comunes y entidades HTML.
+    /// </summary>
+    public static string EscapeText(string? txt)
+    {
+        if (string.IsNullOrEmpty(txt)) return "";
+        return txt
+            .Replace("\\", "\\\\")
+            .Replace("\"", "\\\"")
+            .Replace("\r", " ")
+            .Replace("\n", " ")
+            .Replace("{", "\\{")
+            .Replace("}", "\\}")
+            .Replace("<", "&lt;")
+            .Replace(">", "&gt;")
+            .Replace("[", "&#91;")
+            .Replace("]", "&#93;");
+    }
+}


### PR DESCRIPTION
## Summary
- centralize Mermaid ID/text escaping utilities
- reuse EER choice application logic in controller
- consolidate SQL Server schema reading into single pass and sync API
- modularize Chen diagram builder

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_68b3e4f431dc8330820b396531a9cba7