### PR TITLE
Document database workflows and translator behavior

### DIFF
--- a/Controllers/DiagramaErController.cs
+++ b/Controllers/DiagramaErController.cs
@@ -2,6 +2,9 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Data.SqlClient;
 using System.Linq;
 
+/// <summary>
+/// Controlador encargado del flujo de restaurar un respaldo, leer su esquema y generar los diagramas ER/EER.
+/// </summary>
 public class DiagramaErController : Controller
 {
     private readonly IWebHostEnvironment _entornoWeb;
@@ -27,9 +30,13 @@ public class DiagramaErController : Controller
         _servicioEspecializacion = servicioEspecializacion;
     }
 
+    /// <summary>Muestra el formulario para cargar el respaldo de base de datos.</summary>
     [HttpGet]
     public IActionResult Subir() => View();
 
+    /// <summary>
+    /// Recibe el archivo <c>.bak</c>, lo restaura temporalmente y construye los diagramas ER/EER.
+    /// </summary>
     [HttpPost]
     [RequestSizeLimit(1_000_000_000)]
     public async Task<IActionResult> Subir(IFormFile archivoRespaldo)
@@ -40,25 +47,31 @@ public class DiagramaErController : Controller
             return View();
         }
 
+        // Determina la carpeta donde se almacenará temporalmente el respaldo antes de restaurarlo.
         var carpetaSubida = _configuracion["Upload:Carpeta"] ?? "App_Data/Uploads";
         var rutaCarpetaSubida = Path.Combine(_entornoWeb.ContentRootPath, carpetaSubida);
         Directory.CreateDirectory(rutaCarpetaSubida);
 
         var rutaRespaldo = Path.Combine(rutaCarpetaSubida, $"{Guid.NewGuid():N}.bak");
 
+        // Se guarda el archivo cargado en disco para que SMO pueda consumirlo.
         using (var archivo = System.IO.File.Create(rutaRespaldo))
             await archivoRespaldo.CopyToAsync(archivo);
 
         string nombreBaseRestaurada = string.Empty;
         try
         {
+            // 1. Restaurar el respaldo en SQL Server usando un prefijo identificable.
             nombreBaseRestaurada = await _repositorioRestauracion.RestaurarAsync(rutaRespaldo, "ER");
 
+            // 2. Leer el esquema (tablas, columnas y relaciones) de la base restaurada.
             var esquema = _repositorioEsquema.Leer(nombreBaseRestaurada);
 
             ViewBag.NombreBD = nombreBaseRestaurada;
+            // 3. Construir el diagrama Chen en formato Mermaid.
             ViewBag.Mermaid = _repositorioDiagramaChen.Construir(esquema);
 
+            // 4. Inferir jerarquías para el diagrama EER.
             var jerarquias = InferenciaEER.DetectarJerarquias(esquema);
 
             var constructorCadena = new SqlConnectionStringBuilder(_configuracion.GetConnectionString("SqlMaestra"))
@@ -69,6 +82,7 @@ public class DiagramaErController : Controller
 
             foreach (var jerarquia in jerarquias)
             {
+                // Consulta la especialización directamente en la base restaurada para determinar totalidad y disyunción.
                 var infoEspecializacion = _servicioEspecializacion.AnalizarEspecializacion(
                     cadenaConexionRestaurada,
                     jerarquia.Supertipo,
@@ -89,10 +103,12 @@ public class DiagramaErController : Controller
         }
         finally
         {
+            // Siempre se intenta borrar el archivo físico para no dejar residuos en disco.
             try { System.IO.File.Delete(rutaRespaldo); } catch { }
         }
     }
 
+    /// <summary>Permite eliminar manualmente la base temporal creada tras la restauración.</summary>
     [HttpPost]
     public async Task<IActionResult> EliminarBase(string nombreBD)
     {

--- a/Controllers/RelacionalController.cs
+++ b/Controllers/RelacionalController.cs
@@ -6,6 +6,9 @@ using System;
 using System.IO;
 using System.Threading.Tasks;
 
+/// <summary>
+/// Controlador que gestiona la restauración y generación del modelo relacional textual.
+/// </summary>
 public class RelacionalController : Controller
 {
     private readonly IWebHostEnvironment _entornoWeb;
@@ -28,9 +31,13 @@ public class RelacionalController : Controller
         _repositorioModeloRelacional = repositorioModeloRelacional;
     }
 
+    /// <summary>Muestra la vista para subir el respaldo.</summary>
     [HttpGet]
     public IActionResult Subir() => View();
 
+    /// <summary>
+    /// Restaura el respaldo con un prefijo específico y redirige a la vista del modelo relacional.
+    /// </summary>
     [HttpPost]
     [RequestSizeLimit(1_000_000_000)]
     public async Task<IActionResult> Subir(IFormFile archivoRespaldo)
@@ -41,18 +48,21 @@ public class RelacionalController : Controller
             return View();
         }
 
+        // Guarda el archivo de respaldo en una ubicación temporal.
         var carpetaSubida = _configuracion["Upload:Carpeta"] ?? "App_Data/Uploads";
         var rutaCarpetaSubida = Path.Combine(_entornoWeb.ContentRootPath, carpetaSubida);
         Directory.CreateDirectory(rutaCarpetaSubida);
 
         var rutaRespaldo = Path.Combine(rutaCarpetaSubida, $"{Guid.NewGuid():N}.bak");
 
+        // Copia el contenido subido al archivo temporal.
         using (var archivo = System.IO.File.Create(rutaRespaldo))
             await archivoRespaldo.CopyToAsync(archivo);
 
         string nombreBaseRestaurada = string.Empty;
         try
         {
+            // Restaurar la base con prefijo REL para diferenciarla de las usadas en los diagramas.
             nombreBaseRestaurada = await _repositorioRestauracion.RestaurarAsync(rutaRespaldo, "REL");
             return RedirectToAction("ModeloR", new { nombreBD = nombreBaseRestaurada });
         }
@@ -63,10 +73,14 @@ public class RelacionalController : Controller
         }
         finally
         {
+            // El archivo temporal se elimina siempre que sea posible.
             try { System.IO.File.Delete(rutaRespaldo); } catch { }
         }
     }
 
+    /// <summary>
+    /// Lee el esquema de la base restaurada y construye la salida textual del modelo relacional.
+    /// </summary>
     [HttpGet]
     public IActionResult ModeloR(string nombreBD)
     {
@@ -90,6 +104,7 @@ public class RelacionalController : Controller
         }
     }
 
+    /// <summary>Permite limpiar manualmente la base restaurada una vez generada la documentación.</summary>
     [HttpPost]
     public async Task<IActionResult> EliminarBase(string nombreBD)
     {

--- a/Controllers/TraductorController.cs
+++ b/Controllers/TraductorController.cs
@@ -2,6 +2,9 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace TuProyecto.Controllers
 {
+    /// <summary>
+    /// Controlador que orquesta la interacción del usuario con el traductor AR &lt;-&gt; SQL.
+    /// </summary>
     public class TraductorController : Controller
     {
         private readonly ITraductorRepositorio _repositorioTraductor;
@@ -11,15 +14,20 @@ namespace TuProyecto.Controllers
             _repositorioTraductor = repositorioTraductor;
         }
 
+        /// <summary>Renderiza la vista con el formulario del traductor.</summary>
         [HttpGet]
         public IActionResult Index()
         {
             return View();
         }
 
+        /// <summary>
+        /// Evalúa el texto de entrada según el modo seleccionado y devuelve el resultado al usuario.
+        /// </summary>
         [HttpPost]
         public IActionResult Traducir(string modo, string texto)
         {
+            // Modo AR2SQL interpreta la entrada como álgebra relacional, el otro como SQL.
             string resultado = modo == "AR2SQL"
                 ? _repositorioTraductor.AlgebraRelacionalASql(texto)
                 : _repositorioTraductor.SqlAAlgebraRelacional(texto);

--- a/DOCUMENTACION.md
+++ b/DOCUMENTACION.md
@@ -1,0 +1,92 @@
+# Documentación funcional del proyecto
+
+Este proyecto ASP.NET Core automatiza la restauración temporal de bases de datos SQL Server y genera artefactos educativos a partir de su esquema: diagramas ER/EER, el modelo relacional textual y un traductor entre álgebra relacional y SQL. A continuación se documenta el funcionamiento de cada componente relevante.
+
+## Restauración de respaldos
+
+* **Clase:** `RestauracionRepositorio` (`Repositories/RestauracionRepositorio.cs`).
+* **Responsabilidad:** restaurar archivos `.bak` en una instancia SQL Server usando SQL Server Management Objects (SMO) y eliminarlos cuando dejan de ser necesarios.
+* **Pasos clave:**
+  1. Se genera un nombre único para la base temporal con un prefijo identificable (`ER_`, `REL_`, etc.).
+  2. Se abre la conexión a la base maestra y se crea un `Server` de SMO.
+  3. Se leen los nombres lógicos de los archivos de datos y log para reubicarlos en las rutas por defecto del servidor.
+  4. Se ejecuta `SqlRestore` dentro de un `Task.Run` debido a que SMO solo ofrece API sincrónica.
+  5. Si la restauración falla, se notifica mediante una `InvalidOperationException` para que los controladores muestren el mensaje al usuario.
+  6. La eliminación posterior usa `KillDatabase` de SMO para forzar el cierre de conexiones y limpiar la base temporal.
+
+Los controladores `DiagramaErController` y `RelacionalController` guardan primero el archivo subido en disco y delegan en este repositorio la restauración. Tras completar la operación, eliminan el archivo físico temporal.
+
+## Lectura del esquema restaurado
+
+* **Clase:** `EsquemaRepositorio` (`Repositories/EsquemaRepositorio.cs`).
+* **Responsabilidad:** construir una instantánea del esquema con tablas, columnas, llaves foráneas y tablas puente (`InstantaneaEsquema`).
+* **Proceso:**
+  * Recorre todas las tablas de usuario y registra sus columnas, marcando claves primarias, índices únicos y nulabilidad.
+  * Analiza cada llave foránea para determinar cardinalidades (si la tabla hija es única o permite nulos) y para identificar tablas puente de relaciones muchos-a-muchos.
+  * Los datos recopilados alimentan tanto al generador de diagramas ER como al modelo relacional textual y a la inferencia EER.
+
+## Diagramas ER (Chen)
+
+* **Clase:** `DiagramaChenRepositorio` (`Repositories/DiagramaChenRepositorio.cs`).
+* **Responsabilidad:** convertir `InstantaneaEsquema` en instrucciones Mermaid que representan entidades, atributos y relaciones.
+* **Detalles relevantes:**
+  * Se definen estilos Mermaid para entidades, relaciones y atributos.
+  * Cada tabla de usuario se renderiza como nodo entidad con atributos conectados; las PK se subrayan y los atributos únicos se muestran punteados.
+  * Las llaves foráneas generan relaciones binarias con multiplicidades calculadas según la unicidad y nulabilidad de la tabla hija.
+  * Las tablas puente se dibujan como relaciones muchos-a-muchos con sus atributos propios.
+
+## Inferencia de jerarquías EER
+
+* **Archivo:** `Utils/InferenciaEER.cs` + `Services/EspecializacionEerService.cs` y `Repositories/EspecializacionEerRepositorio.cs`.
+* **Objetivo:** detectar jerarquías de especialización (supertipo/subtipos) y determinar si son totales/disjuntas o parciales/solapadas.
+* **Mecánica:**
+  * `InferenciaEER.DetectarJerarquias` busca claves foráneas únicas que reutilizan exactamente la PK de la tabla hija, indicador de especialización.
+  * Se buscan columnas discriminadoras comunes (`Tipo`, `Clase`, etc.) para ajustar la disyunción.
+  * `EspecializacionEerService` consulta directamente la base restaurada para verificar si todos los padres tienen hijo (totalidad) y si los subtipos se solapan (intersección).
+  * `InferenciaEER.RenderMermaidEER` arma un diagrama Mermaid adicional que muestra cada jerarquía con sus etiquetas.
+
+## Modelo relacional en texto
+
+* **Clase:** `ModeloRelacionalTextoRepositorio` (`Repositories/ModeloRelacionalTextoRepositorio.cs`).
+* **Responsabilidad:** generar una lista ordenada de relaciones en notación `Tabla(atributos)` o en HTML enriquecido.
+* **Funcionamiento:**
+  * Determina qué atributos actúan como claves foráneas y resalta primero las claves primarias y candidatos únicos.
+  * Cada atributo recibe etiquetas `[PK]`, `[FK]`, `[UK]` en modo texto o marcado HTML (subrayado/cursiva) en modo visual.
+  * El controlador `RelacionalController` muestra esta salida en la vista `ModeloR` y permite eliminar la base temporal al finalizar.
+
+## Traductor Álgebra Relacional ↔ SQL
+
+* **Clase:** `TraductorRepositorio` (`Repositories/TraductorRepositorio.cs`).
+* **Responsabilidad:** interpretar un subconjunto común de expresiones en álgebra relacional (selección, proyección, unión, diferencia, join y división) y traducirlas a SQL, y viceversa.
+* **Estrategia:**
+  * Se definen expresiones regulares específicas para cada operador o patrón SQL.
+  * En la dirección AR→SQL se combinan las coincidencias para construir sentencias `SELECT`, `JOIN`, `UNION`, `EXCEPT` y el patrón clásico de división.
+  * En la dirección SQL→AR se mapea cada cláusula `SELECT`, `JOIN`, `WHERE`, `UNION` o `EXCEPT` a los operadores σ, π, ⋈, ∪ y −.
+  * El `TraductorController` recibe el modo solicitado, invoca al repositorio y retorna el resultado en la misma vista.
+
+## Flujo completo para diagramas ER/EER
+
+1. El usuario accede a `/DiagramaEr/Subir` y sube un archivo `.bak`.
+2. `DiagramaErController.Subir` guarda el respaldo temporalmente, lo restaura (`RestauracionRepositorio`), lee el esquema (`EsquemaRepositorio`) y genera los diagramas (`DiagramaChenRepositorio` y `InferenciaEER`).
+3. Se calculan las etiquetas de especialización (`EspecializacionEerService`) y se representa la jerarquía con Mermaid.
+4. La vista `Resultado` muestra el nombre de la base, el diagrama ER y el EER; también ofrece un botón para eliminar la base restaurada.
+
+## Flujo para modelo relacional textual
+
+1. El usuario visita `/Relacional/Subir` y carga el respaldo.
+2. Tras restaurar la base, el controlador redirige a `ModeloR`, que invoca a `ModeloRelacionalTextoRepositorio` para obtener la notación textual.
+3. La vista muestra el modelo y un botón para eliminar la base temporal.
+
+## Flujo del traductor
+
+1. Se ingresa a `/Traductor` y se selecciona el modo de traducción (AR→SQL o SQL→AR).
+2. `TraductorController.Traducir` procesa el texto con el repositorio correspondiente.
+3. El resultado y el modo elegido se devuelven a la vista para permitir refinamientos sucesivos.
+
+## Limpieza y seguridad
+
+* Todos los controladores eliminan el archivo `.bak` temporal al terminar (bloque `finally`).
+* Se ofrece una acción explícita para eliminar la base restaurada (`EliminarBase`) a fin de liberar recursos del servidor SQL.
+* Los nombres de las bases restauradas usan GUIDs con prefijos para evitar colisiones.
+
+Esta documentación debe servir como guía de referencia rápida para comprender cómo el proyecto restaura respaldos, reconstruye el conocimiento del modelo de datos y ofrece utilidades de apoyo académico.

--- a/Repositories/DiagramaChenRepositorio.cs
+++ b/Repositories/DiagramaChenRepositorio.cs
@@ -3,8 +3,14 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
+/// <summary>
+/// Expone la capacidad de transformar un esquema relacional en instrucciones Mermaid de un ER (Chen).
+/// </summary>
 public interface IDiagramaChenRepositorio
 {
+    /// <summary>
+    /// Construye la definición Mermaid para representar entidades, atributos y relaciones.
+    /// </summary>
     string Construir(InstantaneaEsquema esquema);
 }
 
@@ -15,6 +21,7 @@ public class DiagramaChenRepositorio : IDiagramaChenRepositorio
 
     public string Construir(InstantaneaEsquema esquema)
     {
+        // Se arma el encabezado del diagrama Mermaid, declarando estilos reutilizables para cada elemento.
         var sb = new StringBuilder();
         sb.AppendLine("flowchart LR");
         sb.AppendLine("classDef entidad fill:#eef,stroke:#334,stroke-width:1px,rx:8,ry:8;");
@@ -23,6 +30,7 @@ public class DiagramaChenRepositorio : IDiagramaChenRepositorio
         sb.AppendLine("classDef clave font-weight:bold,text-decoration:underline;");
         sb.AppendLine("classDef unico stroke-dasharray:3 2;");
 
+        // Se renderizan por separado entidades, relaciones binarias y relaciones M:N para mantener el código organizado.
         RenderizarEntidades(sb, esquema);
         RenderizarRelacionesBinarias(sb, esquema);
         RenderizarRelacionesMuchosAMuchos(sb, esquema);
@@ -37,6 +45,7 @@ public class DiagramaChenRepositorio : IDiagramaChenRepositorio
             if (TablasIgnoradas.Contains(tabla.Nombre)) continue;
             if (esquema.TablasUnionMuchosAMuchos.Contains(tabla.Nombre)) continue;
 
+            // Cada tabla se convierte en un nodo "entidad" y se le agregan nodos hijos por cada columna.
             var idEntidad = MermaidUtils.Sanitizar(tabla.Nombre);
             sb.AppendLine($"  {idEntidad}[{MermaidUtils.Escapar(tabla.Nombre)}]:::entidad");
 
@@ -45,9 +54,11 @@ public class DiagramaChenRepositorio : IDiagramaChenRepositorio
                 var idAtributo = $"{idEntidad}__{MermaidUtils.Sanitizar(columna.Nombre)}";
                 sb.AppendLine($"  {idAtributo}(({MermaidUtils.Escapar(columna.Nombre)})):::atributo");
 
+                // Se asignan clases CSS para resaltar claves primarias o candidatos únicos.
                 if (columna.EsPk) sb.AppendLine($"  class {idAtributo} clave;");
                 else if (columna.EsUnicoCandidato) sb.AppendLine($"  class {idAtributo} unico;");
 
+                // El atributo se conecta visualmente con su entidad.
                 sb.AppendLine($"  {idAtributo} --- {idEntidad}");
             }
         }
@@ -61,6 +72,7 @@ public class DiagramaChenRepositorio : IDiagramaChenRepositorio
             if (TablasIgnoradas.Contains(relacion.TablaPadre) || TablasIgnoradas.Contains(relacion.TablaHija)) continue;
             if (esquema.TablasUnionMuchosAMuchos.Contains(relacion.TablaHija)) continue;
 
+            // Cada relación se modela como un rombo y se le asocia un identificador único incremental.
             var idRelacion = $"REL_{contador++}_{MermaidUtils.Sanitizar(relacion.Nombre)}";
             sb.AppendLine($"  {idRelacion}{{{{{MermaidUtils.Escapar(relacion.Nombre)}}}}}:::relacion");
             sb.AppendLine($"  {MermaidUtils.Sanitizar(relacion.TablaPadre)} -- \"1\" --> {idRelacion}");
@@ -69,6 +81,7 @@ public class DiagramaChenRepositorio : IDiagramaChenRepositorio
                 ? (relacion.HijaTodasNoNulas ? "1" : "0..1")
                 : (relacion.HijaTodasNoNulas ? "1..N" : "0..N");
 
+            // Cuando la tabla hija admite valores nulos se utilizan líneas punteadas para indicar opcionalidad.
             if (relacion.HijaTodasNoNulas)
                 sb.AppendLine($"  {idRelacion} -- \"{multiplicidad}\" --> {MermaidUtils.Sanitizar(relacion.TablaHija)}");
             else
@@ -82,6 +95,7 @@ public class DiagramaChenRepositorio : IDiagramaChenRepositorio
         {
             if (TablasIgnoradas.Contains(tablaPuente)) continue;
 
+            // Una tabla puente debe tener exactamente dos claves foráneas para que se interprete como relación M:N.
             var padres = esquema.LlavesForaneas
                 .Where(f => f.TablaHija == tablaPuente)
                 .Select(f => f.TablaPadre)
@@ -93,9 +107,11 @@ public class DiagramaChenRepositorio : IDiagramaChenRepositorio
                 var idRelacion = $"MN_{MermaidUtils.Sanitizar(tablaPuente)}";
                 sb.AppendLine($"  {idRelacion}{{{{{MermaidUtils.Escapar(tablaPuente)}}}}}:::relacion");
 
+                // Se conectan ambos padres con multiplicidad "1..N" para reflejar la cardinalidad típica de una tabla puente.
                 sb.AppendLine($"  {MermaidUtils.Sanitizar(padres[0])} -- \"1..N\" --> {idRelacion}");
                 sb.AppendLine($"  {idRelacion} -- \"1..N\" --> {MermaidUtils.Sanitizar(padres[1])}");
 
+                // Las columnas no involucradas en las FKs se muestran como atributos propios de la relación M:N.
                 var columnasFk = new HashSet<string>(
                     esquema.LlavesForaneas.Where(f => f.TablaHija == tablaPuente)
                         .SelectMany(f => f.ColumnasHijaCsv.Split(',').Select(x => x.Trim())),

--- a/Repositories/EspecializacionEerRepositorio.cs
+++ b/Repositories/EspecializacionEerRepositorio.cs
@@ -4,9 +4,14 @@ using Microsoft.SqlServer.Management.Smo;
 using System.Collections.Generic;
 using System.Linq;
 
+/// <summary>
+/// Operaciones de bajo nivel para inspeccionar especializaciones EER directamente en SQL Server.
+/// </summary>
 public interface IEspecializacionEerRepositorio
 {
+    /// <summary>Obtiene los identificadores del supertipo que no aparecen en ningún subtipo.</summary>
     IEnumerable<int> ObtenerPadresSinHijo(string conexion, string entidadPadre, params string[] entidadesHija);
+    /// <summary>Calcula cuántos registros aparecen en más de un subtipo (intersecciones).</summary>
     int ObtenerIntersecciones(string conexion, string entidadPadre, params string[] entidadesHija);
 }
 
@@ -14,6 +19,7 @@ public class EspecializacionEerRepositorio : IEspecializacionEerRepositorio
 {
     public IEnumerable<int> ObtenerPadresSinHijo(string conexion, string entidadPadre, params string[] entidadesHija)
     {
+        // Esta consulta identifica participación total comparando la tabla padre con la unión de sus subtipos.
         var resultado = new List<int>();
         using var cn = new SqlConnection(conexion);
         cn.Open();
@@ -25,6 +31,7 @@ public class EspecializacionEerRepositorio : IEspecializacionEerRepositorio
         var selects = new List<string>();
         foreach (var hija in entidadesHija)
         {
+            // Para cada subtipo se obtiene la columna FK que referencia al supertipo.
             var columnaFk = ObtenerColumnaFk(bd, hija, entidadPadre);
             selects.Add($"SELECT {columnaFk} AS IdPadre FROM {hija}");
         }
@@ -37,6 +44,7 @@ public class EspecializacionEerRepositorio : IEspecializacionEerRepositorio
             LEFT JOIN ({joinedChildren}) h ON p.{columnaPk} = h.IdPadre
             WHERE h.IdPadre IS NULL";
 
+        // Ejecuta la consulta y recolecta los identificadores que no tienen correspondencia en los subtipos.
         using var cmd = new SqlCommand(sql, cn);
         using var rd = cmd.ExecuteReader();
         while (rd.Read())
@@ -57,6 +65,7 @@ public class EspecializacionEerRepositorio : IEspecializacionEerRepositorio
         {
             for (int j = i + 1; j < entidadesHija.Length; j++)
             {
+                // Se obtienen las columnas FK de ambos subtipos y se realiza un JOIN para contar registros comunes.
                 var fk1 = ObtenerColumnaFk(bd, entidadesHija[i], entidadPadre);
                 var fk2 = ObtenerColumnaFk(bd, entidadesHija[j], entidadPadre);
 

--- a/Repositories/EsquemaRepositorio.cs
+++ b/Repositories/EsquemaRepositorio.cs
@@ -8,10 +8,19 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
+/// <summary>
+/// Representa únicamente el nombre físico de una tabla encontrada en la base restaurada.
+/// </summary>
 public record InfoTabla(string Nombre);
 
+/// <summary>
+/// Describe cada columna de la base y si interviene como PK o candidata única.
+/// </summary>
 public record InfoColumna(string Tabla, string Nombre, string Tipo, bool EsNulo, bool EsPk, bool EsUnicoCandidato);
 
+/// <summary>
+/// Contiene el detalle de cada restricción de clave foránea detectada en el esquema.
+/// </summary>
 public record InfoLlaveForanea(
     string Nombre, string TablaPadre, string TablaHija,
     string ColumnasPadreCsv, string ColumnasHijaCsv,
@@ -19,9 +28,15 @@ public record InfoLlaveForanea(
 
 public class InstantaneaEsquema
 {
+    /// <summary>Listado de tablas de usuario presentes en la base.</summary>
     public List<InfoTabla> Tablas { get; } = new();
+    /// <summary>Listado completo de columnas con metadatos enriquecidos.</summary>
     public List<InfoColumna> Columnas { get; } = new();
+    /// <summary>Información de todas las claves foráneas para reconstruir las relaciones.</summary>
     public List<InfoLlaveForanea> LlavesForaneas { get; } = new();
+    /// <summary>
+    /// Identifica tablas que actúan como puentes en relaciones muchos a muchos para tratarlas de forma especial.
+    /// </summary>
     public HashSet<string> TablasUnionMuchosAMuchos { get; } = new();
 }
 
@@ -39,21 +54,30 @@ public class EsquemaRepositorio : IEsquemaRepositorio
         cadenaMaestra = configuracion.GetConnectionString("SqlMaestra")!;
     }
 
+    /// <summary>
+    /// Abre la base restaurada y genera una instantánea del esquema necesario para los diagramas.
+    /// </summary>
     public InstantaneaEsquema Leer(string nombreBd)
     {
         var esquema = new InstantaneaEsquema();
 
+        // Se reutiliza la cadena maestra porque SMO permite cambiar de base a través del objeto Server.
         using var conexion = new SqlConnection(cadenaMaestra);
         var servidor = new Server(new ServerConnection(conexion));
+        // Se obtiene la referencia a la base restaurada por nombre.
         var bd = servidor.Databases[nombreBd];
 
+        // Recorre cada tabla de usuario (omitiendo objetos del sistema) para cargar columnas y claves foráneas.
         foreach (Table tabla in bd.Tables)
         {
             if (tabla.IsSystemObject)
                 continue;
 
+            // Registra el nombre de la tabla en la instantánea.
             esquema.Tablas.Add(new InfoTabla(tabla.Name));
+            // Almacena las columnas básicas de la tabla.
             RegistrarColumnas(tabla, esquema);
+            // Revisa las relaciones de la tabla con otras.
             AnalizarLlavesForaneas(tabla, esquema);
         }
 
@@ -62,9 +86,11 @@ public class EsquemaRepositorio : IEsquemaRepositorio
 
     private static void RegistrarColumnas(Table tabla, InstantaneaEsquema esquema)
     {
+        // Obtiene un conjunto con los nombres de columnas que tienen índices únicos para marcarlas como candidatos.
         var columnasUnicas = ObtenerColumnasUnicas(tabla);
         foreach (Column columna in tabla.Columns)
         {
+            // Agrega cada columna con la metadata que se utiliza luego para etiquetar PK, nulos y únicos.
             esquema.Columnas.Add(new InfoColumna(
                 tabla.Name,
                 columna.Name,
@@ -78,6 +104,8 @@ public class EsquemaRepositorio : IEsquemaRepositorio
     private static HashSet<string> ObtenerColumnasUnicas(Table tabla)
     {
         var resultado = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        // Se recorre cada índice definido en la tabla y se seleccionan únicamente los índices únicos
+        // que no corresponden a la clave primaria (ya se marcan por separado).
         foreach (SmoIndex indice in tabla.Indexes)
             if (indice.IsUnique && indice.IndexKeyType != IndexKeyType.DriPrimaryKey)
                 foreach (SmoIndexedColumn col in indice.IndexedColumns)
@@ -89,6 +117,7 @@ public class EsquemaRepositorio : IEsquemaRepositorio
     {
         int cantidadFks = 0;
         var tablasReferenciadas = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        // Obtiene las columnas que forman parte de la clave primaria para usarlas al detectar tablas puente.
         var columnasPk = tabla.Indexes.Cast<SmoIndex>()
             .FirstOrDefault(i => i.IndexKeyType == IndexKeyType.DriPrimaryKey)?
             .IndexedColumns.Cast<SmoIndexedColumn>()
@@ -102,17 +131,20 @@ public class EsquemaRepositorio : IEsquemaRepositorio
 
             var colsPadre = new List<string>();
             var colsHija = new List<string>();
+            // Cada columna de la clave foránea se descompone en su columna padre e hija.
             foreach (ForeignKeyColumn columnaFk in fk.Columns)
             {
                 colsPadre.Add(columnaFk.ReferencedColumn);
                 colsHija.Add(columnaFk.Name);
             }
 
+            // Se determina si la combinación de columnas hijas es única para inferir cardinalidades.
             bool hijaUnica = tabla.Indexes.Cast<SmoIndex>().Any(i =>
                 i.IsUnique &&
                 string.Join("|", i.IndexedColumns.Cast<SmoIndexedColumn>().Select(ic => ic.Name)) ==
                 string.Join("|", colsHija));
 
+            // También se verifica si todas las columnas hijas son NOT NULL para decidir si la participación es total.
             bool hijaNoNula = colsHija.All(cn => !tabla.Columns[cn].Nullable);
 
             esquema.LlavesForaneas.Add(new InfoLlaveForanea(
@@ -125,6 +157,8 @@ public class EsquemaRepositorio : IEsquemaRepositorio
                 hijaNoNula));
         }
 
+        // Si la tabla tiene dos claves foráneas y su PK está formada por las mismas columnas, se considera
+        // como tabla puente de una relación muchos a muchos y se marca para un renderizado especial.
         if (columnasPk.Count == 2 && cantidadFks >= 2 && tablasReferenciadas.Count == 2)
             esquema.TablasUnionMuchosAMuchos.Add(tabla.Name);
     }

--- a/Repositories/ModeloRelacionalTextoRepositorio.cs
+++ b/Repositories/ModeloRelacionalTextoRepositorio.cs
@@ -3,8 +3,16 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
+/// <summary>
+/// Define cómo transformar el esquema restaurado en un modelo relacional descrito en texto plano o HTML.
+/// </summary>
 public interface IModeloRelacionalTextoRepositorio
 {
+    /// <summary>
+    /// Construye la representación textual del modelo relacional.
+    /// </summary>
+    /// <param name="esquema">Instantánea del esquema que contiene tablas, columnas y relaciones.</param>
+    /// <param name="comoHtml">Si es verdadero, genera etiquetas HTML para mostrarlo en la vista.</param>
     string Construir(InstantaneaEsquema esquema, bool comoHtml = false);
 }
 
@@ -12,8 +20,10 @@ public class ModeloRelacionalTextoRepositorio : IModeloRelacionalTextoRepositori
 {
     public string Construir(InstantaneaEsquema esquema, bool comoHtml = false)
     {
+        // Se utiliza StringBuilder para producir un listado detallado de tablas y atributos.
         var sb = new StringBuilder();
 
+        // Se agrupan las columnas que pertenecen a claves foráneas por tabla para etiquetar atributos como FK.
         var fksPorTabla = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
         foreach (var fk in esquema.LlavesForaneas)
         {
@@ -24,6 +34,7 @@ public class ModeloRelacionalTextoRepositorio : IModeloRelacionalTextoRepositori
                 set.Add(c);
         }
 
+        // Se ordenan las tablas por nombre para presentar un modelo estable y fácil de leer.
         foreach (var tabla in esquema.Tablas.Select(t => t.Nombre).OrderBy(n => n))
         {
             if (tabla.StartsWith("EER_", StringComparison.OrdinalIgnoreCase))
@@ -31,6 +42,7 @@ public class ModeloRelacionalTextoRepositorio : IModeloRelacionalTextoRepositori
 
             var cols = esquema.Columnas.Where(c => c.Tabla == tabla).ToList();
 
+            // Ordena atributos resaltando primero las claves primarias y únicas para facilitar la lectura.
             var ordenadas = cols
                 .OrderByDescending(c => c.EsPk)
                 .ThenByDescending(c => c.EsUnicoCandidato && !c.EsPk)
@@ -41,6 +53,7 @@ public class ModeloRelacionalTextoRepositorio : IModeloRelacionalTextoRepositori
             {
                 if (comoHtml)
                 {
+                    // En modo HTML se agregan etiquetas para subrayar PKs, cursiva para FKs y marcas para únicos.
                     var n = nombre;
                     if (esPk) n = $"<u>{n}</u>";
                     if (esFk) n = $"<i>{n}</i>";
@@ -48,6 +61,7 @@ public class ModeloRelacionalTextoRepositorio : IModeloRelacionalTextoRepositori
                     if (esPk && esFk) n += " <small>[FK]</small>";
                     return n;
                 }
+                // En modo texto plano se agregan sufijos entre corchetes con las etiquetas correspondientes.
                 var tags = new List<string>();
                 if (esPk) tags.Add("PK");
                 if (esFk) tags.Add("FK");
@@ -57,11 +71,13 @@ public class ModeloRelacionalTextoRepositorio : IModeloRelacionalTextoRepositori
 
             var fkSet = fksPorTabla.TryGetValue(tabla, out var s) ? s : new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
+            // Cada atributo se formatea con su etiqueta y se concatena como parte de la lista de columnas.
             var atributos = ordenadas.Select(c =>
                 Formatear(c.Nombre, c.EsPk, fkSet.Contains(c.Nombre), c.EsUnicoCandidato)
             );
 
             if (comoHtml)
+                // En HTML se envuelve la salida en un <div> para facilitar el estilo en la vista.
                 sb.AppendLine($"<div><b>{tabla}</b>({string.Join(", ", atributos)})</div>");
             else
                 sb.AppendLine($"{tabla}({string.Join(", ", atributos)})");

--- a/Repositories/RestauracionRepositorio.cs
+++ b/Repositories/RestauracionRepositorio.cs
@@ -2,9 +2,23 @@ using Microsoft.Data.SqlClient;
 using Microsoft.SqlServer.Management.Common;
 using Microsoft.SqlServer.Management.Smo;
 
+/// <summary>
+/// Define las operaciones relacionadas con la restauración y eliminación
+/// temporal de bases de datos a partir de archivos <c>.bak</c>.
+/// </summary>
 public interface IRestauracionRepositorio
 {
+    /// <summary>
+    /// Restaura un archivo de respaldo en el servidor SQL y devuelve el nombre de la base creada.
+    /// </summary>
+    /// <param name="rutaRespaldo">Ruta física del archivo <c>.bak</c> que se desea restaurar.</param>
+    /// <param name="prefijo">Prefijo que se utiliza para nombrar la base temporal restaurada.</param>
     Task<string> RestaurarAsync(string rutaRespaldo, string prefijo = "ER");
+
+    /// <summary>
+    /// Elimina la base de datos restaurada del servidor SQL para liberar recursos.
+    /// </summary>
+    /// <param name="nombreBd">Nombre de la base de datos que se desea eliminar.</param>
     Task EliminarBaseDatosAsync(string nombreBd);
 }
 
@@ -17,52 +31,84 @@ public class RestauracionRepositorio : IRestauracionRepositorio
         _cadenaConexionMaestra = configuracion.GetConnectionString("SqlMaestra")!;
     }
 
+    /// <summary>
+    /// Ejecuta paso a paso la restauración de un archivo <c>.bak</c> en SQL Server.
+    /// </summary>
+    /// <remarks>
+    /// Cada fragmento del método está documentado para clarificar cómo se construye el nombre
+    /// de la base temporal, cómo se configuran las rutas de datos y logs y cómo se ejecuta el
+    /// comando de restauración mediante SMO (SQL Server Management Objects).
+    /// </remarks>
     public async Task<string> RestaurarAsync(string rutaRespaldo, string prefijo = "ER")
     {
+        // Se genera un nombre único utilizando el prefijo indicado. Las bases restauradas
+        // se nombran así para que sean fáciles de identificar y evitar colisiones.
         string nombreBd = $"{prefijo}_{Guid.NewGuid():N}".ToUpper();
 
         try
         {
+            // Abre una conexión a la base maestra del servidor donde se restaurará el respaldo.
             using var conexion = new SqlConnection(_cadenaConexionMaestra);
             await conexion.OpenAsync();
+
+            // SMO requiere envolver la conexión en un ServerConnection para poder invocar
+            // operaciones administrativas como la restauración.
             var servidor = new Server(new ServerConnection(conexion));
 
+            // Recupera las rutas por defecto configuradas en SQL Server para los archivos MDF y LDF.
             string rutaDatos = servidor.DefaultFile;
             string rutaLogs = servidor.DefaultLog;
 
+            // Configura el objeto Restore indicando que se trata de una restauración completa
+            // de base de datos y que se debe reemplazar cualquier base existente con el mismo nombre.
             var restauracion = new Restore
             {
                 Database = nombreBd,
                 Action = RestoreActionType.Database,
                 ReplaceDatabase = true
             };
+            // El archivo .bak se agrega como dispositivo de entrada de la restauración.
             restauracion.Devices.AddDevice(rutaRespaldo, DeviceType.File);
 
+            // ReadFileList obtiene los nombres lógicos originales de los archivos de datos y log
+            // almacenados en el respaldo para poder reubicarlos en la instancia actual.
             var listaArchivos = restauracion.ReadFileList(servidor);
             string nombreLogicoDatos = listaArchivos.Rows[0]["LogicalName"].ToString()!;
             string nombreLogicoLog = listaArchivos.Rows[1]["LogicalName"].ToString()!;
 
+            // Define la nueva ruta física para los archivos restaurados dentro del servidor.
             string rutaMdf = Path.Combine(rutaDatos, $"{nombreBd}.mdf");
             string rutaLdf = Path.Combine(rutaLogs, $"{nombreBd}_log.ldf");
 
+            // RelocateFiles indica a SMO que coloque los archivos físicos en las rutas calculadas
+            // en lugar de las rutas originales almacenadas en el respaldo.
             restauracion.RelocateFiles.Add(new RelocateFile(nombreLogicoDatos, rutaMdf));
             restauracion.RelocateFiles.Add(new RelocateFile(nombreLogicoLog, rutaLdf));
 
+            // Ejecuta la restauración. Se usa Task.Run porque SMO sólo ofrece API sincrónica.
             await Task.Run(() => restauracion.SqlRestore(servidor));
         }
         catch (SmoException ex)
         {
+            // Cualquier error de SMO se envuelve en InvalidOperationException para que el
+            // controlador pueda mostrar un mensaje amigable al usuario.
             throw new InvalidOperationException("Error al restaurar la base de datos.", ex);
         }
 
         return nombreBd;
     }
 
+    /// <summary>
+    /// Elimina una base de datos temporal previamente restaurada.
+    /// </summary>
     public async Task EliminarBaseDatosAsync(string nombreBd)
     {
+        // Abre una conexión a la base maestra y crea un objeto Server de SMO.
         using var conexion = new SqlConnection(_cadenaConexionMaestra);
         await conexion.OpenAsync();
         var servidor = new Server(new ServerConnection(conexion));
+
+        // KillDatabase fuerza la eliminación incluso si hay conexiones pendientes.
         await Task.Run(() => servidor.KillDatabase(nombreBd));
     }
 }

--- a/Repositories/TraductorRepositorio.cs
+++ b/Repositories/TraductorRepositorio.cs
@@ -1,13 +1,19 @@
 using System.Text.RegularExpressions;
 
+/// <summary>
+/// Define las operaciones del traductor bidireccional entre álgebra relacional y SQL.
+/// </summary>
 public interface ITraductorRepositorio
 {
+    /// <summary>Convierte expresiones en álgebra relacional extendida a instrucciones SQL.</summary>
     string AlgebraRelacionalASql(string entrada);
+    /// <summary>Convierte sentencias SQL sencillas a su equivalente en álgebra relacional.</summary>
     string SqlAAlgebraRelacional(string entrada);
 }
 
 public class TraductorRepositorio : ITraductorRepositorio
 {
+    // Expresiones regulares que capturan los diferentes operadores de álgebra relacional soportados.
     private static readonly Regex SeleccionRegex = new(@"^σ_\{(.+?)\}\((.+)\)$", RegexOptions.Compiled);
     private static readonly Regex ProyeccionRegex = new(@"^π_\{(.+?)\}\((.+)\)$", RegexOptions.Compiled);
     private static readonly Regex UnionNaturalRegex = new(@"^(.+)\s*⋈_\{(.+?)\}\s*(.+)$", RegexOptions.Compiled);
@@ -15,6 +21,7 @@ public class TraductorRepositorio : ITraductorRepositorio
     private static readonly Regex DiferenciaRegex = new(@"^(.+)\s*−\s*(.+)$", RegexOptions.Compiled);
     private static readonly Regex DivisionRegex = new(@"DIV\((.+); by\[(.+)\]; keep\[(.+)\]\)", RegexOptions.Compiled);
 
+    // Expresiones regulares para reconocer patrones comunes de SQL SELECT / JOIN / UNION.
     private static readonly Regex SqlSeleccionRegex = new(@"^SELECT (.+) FROM (\w+)(?:\s+(\w+))? WHERE (.+)$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
     private static readonly Regex SqlProyeccionRegex = new(@"^SELECT (.+) FROM (\w+)(?:\s+(\w+))?$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
     private static readonly Regex SqlUnionNaturalWhereRegex = new(@"^SELECT (.+) FROM (\w+)(?:\s+(\w+))? JOIN (\w+)(?:\s+(\w+))? ON (.+) WHERE (.+)$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
@@ -24,6 +31,7 @@ public class TraductorRepositorio : ITraductorRepositorio
 
     public string AlgebraRelacionalASql(string algebra)
     {
+        // Normaliza la entrada eliminando espacios sobrantes y puntos y coma finales.
         algebra = algebra.Trim().TrimEnd(';');
 
         var seleccion = SeleccionRegex.Match(algebra);
@@ -33,15 +41,18 @@ public class TraductorRepositorio : ITraductorRepositorio
             var proyeccionInterna = ProyeccionRegex.Match(cuerpo);
             if (proyeccionInterna.Success)
             {
+                // Caso: σ{cond}(π{campos}(R)) -> SELECT campos FROM R WHERE cond
                 var cuerpoProyeccion = proyeccionInterna.Groups[2].Value.Trim();
                 var unionInterna = UnionNaturalRegex.Match(cuerpoProyeccion);
                 if (unionInterna.Success)
+                    // Caso: selección sobre un JOIN representado con ⋈.
                     return $"SELECT {proyeccionInterna.Groups[1].Value} FROM {unionInterna.Groups[1].Value.Trim()} JOIN {unionInterna.Groups[3].Value.Trim()} ON {unionInterna.Groups[2].Value.Trim()} WHERE {seleccion.Groups[1].Value}";
                 return $"SELECT {proyeccionInterna.Groups[1].Value} FROM {cuerpoProyeccion} WHERE {seleccion.Groups[1].Value}";
             }
 
             var unionInternaDentro = UnionNaturalRegex.Match(cuerpo);
             if (unionInternaDentro.Success)
+                // Selección directamente sobre un JOIN.
                 return $"SELECT * FROM {unionInternaDentro.Groups[1].Value.Trim()} JOIN {unionInternaDentro.Groups[3].Value.Trim()} ON {unionInternaDentro.Groups[2].Value.Trim()} WHERE {seleccion.Groups[1].Value}";
 
             return $"SELECT * FROM {cuerpo} WHERE {seleccion.Groups[1].Value}";
@@ -53,10 +64,12 @@ public class TraductorRepositorio : ITraductorRepositorio
             var cuerpo = proyeccion.Groups[2].Value.Trim();
             var seleccionInterna = SeleccionRegex.Match(cuerpo);
             if (seleccionInterna.Success)
+                // π{campos}(σ{cond}(R)) -> SELECT campos FROM R WHERE cond
                 return $"SELECT {proyeccion.Groups[1].Value} FROM {seleccionInterna.Groups[2].Value} WHERE {seleccionInterna.Groups[1].Value}";
 
             var unionInterna = UnionNaturalRegex.Match(cuerpo);
             if (unionInterna.Success)
+                // π{campos}(R ⋈_{cond} S) -> SELECT campos FROM R JOIN S ON cond
                 return $"SELECT {proyeccion.Groups[1].Value} FROM {unionInterna.Groups[1].Value.Trim()} JOIN {unionInterna.Groups[3].Value.Trim()} ON {unionInterna.Groups[2].Value.Trim()}";
 
             return $"SELECT {proyeccion.Groups[1].Value} FROM {cuerpo}";
@@ -64,14 +77,17 @@ public class TraductorRepositorio : ITraductorRepositorio
 
         var unionNatural = UnionNaturalRegex.Match(algebra);
         if (unionNatural.Success)
+            // R ⋈_{cond} S -> SELECT * FROM R JOIN S ON cond
             return $"SELECT * FROM {unionNatural.Groups[1].Value.Trim()} JOIN {unionNatural.Groups[3].Value.Trim()} ON {unionNatural.Groups[2].Value.Trim()}";
 
         var unionConjuntos = UnionRegex.Match(algebra);
         if (unionConjuntos.Success)
+            // Unión de conjuntos.
             return $"SELECT * FROM {unionConjuntos.Groups[1].Value.Trim()} UNION SELECT * FROM {unionConjuntos.Groups[2].Value.Trim()}";
 
         var diferencia = DiferenciaRegex.Match(algebra);
         if (diferencia.Success)
+            // Diferencia de conjuntos.
             return $"SELECT * FROM {diferencia.Groups[1].Value.Trim()} EXCEPT SELECT * FROM {diferencia.Groups[2].Value.Trim()}";
 
         var division = DivisionRegex.Match(algebra);
@@ -80,6 +96,7 @@ public class TraductorRepositorio : ITraductorRepositorio
             var tabla = division.Groups[1].Value.Trim();
             var por = division.Groups[2].Value.Trim();
             var conservar = division.Groups[3].Value.Trim();
+            // Traducción de DIV basada en el patrón clásico con doble NOT EXISTS.
             return $@"SELECT DISTINCT {conservar}
 FROM {tabla} AS A
 WHERE NOT EXISTS (
@@ -96,14 +113,17 @@ WHERE NOT EXISTS (
 
     public string SqlAAlgebraRelacional(string sql)
     {
+        // Normaliza la sentencia SQL previa a los análisis con expresiones regulares.
         sql = sql.Trim().TrimEnd(';');
 
         var unionSql = SqlUnionRegex.Match(sql);
         if (unionSql.Success)
+            // UNION en SQL -> unión de conjuntos en álgebra.
             return $"({SqlAAlgebraRelacional(unionSql.Groups[1].Value)}) ∪ ({SqlAAlgebraRelacional(unionSql.Groups[2].Value)})";
 
         var exceptoSql = SqlExceptoRegex.Match(sql);
         if (exceptoSql.Success)
+            // EXCEPT -> diferencia de conjuntos.
             return $"({SqlAAlgebraRelacional(exceptoSql.Groups[1].Value)}) − ({SqlAAlgebraRelacional(exceptoSql.Groups[2].Value)})";
 
         var unionNaturalWhereSql = SqlUnionNaturalWhereRegex.Match(sql);
@@ -115,6 +135,7 @@ WHERE NOT EXISTS (
             var alias2 = unionNaturalWhereSql.Groups[5].Value.Trim();
             var izquierda = string.IsNullOrEmpty(alias1) ? tabla1 : $"{tabla1} {alias1}";
             var derecha = string.IsNullOrEmpty(alias2) ? tabla2 : $"{tabla2} {alias2}";
+            // SELECT ... JOIN ... WHERE ... -> σ(π(R ⋈ S)).
             return $"σ_{{{unionNaturalWhereSql.Groups[7].Value.Trim()}}}(π_{{{unionNaturalWhereSql.Groups[1].Value.Trim()}}}({izquierda} ⋈_{{{unionNaturalWhereSql.Groups[6].Value.Trim()}}} {derecha}))";
         }
 
@@ -124,6 +145,7 @@ WHERE NOT EXISTS (
             var tabla = seleccion.Groups[2].Value.Trim();
             var alias = seleccion.Groups[3].Value.Trim();
             var tablaResuelta = string.IsNullOrEmpty(alias) ? tabla : $"{tabla} {alias}";
+            // SELECT ... WHERE ... -> σ(π(R)).
             return $"σ_{{{seleccion.Groups[4].Value.Trim()}}}(π_{{{seleccion.Groups[1].Value.Trim()}}}({tablaResuelta}))";
         }
 
@@ -136,6 +158,7 @@ WHERE NOT EXISTS (
             var alias2 = unionNaturalSql.Groups[5].Value.Trim();
             var izquierda = string.IsNullOrEmpty(alias1) ? tabla1 : $"{tabla1} {alias1}";
             var derecha = string.IsNullOrEmpty(alias2) ? tabla2 : $"{tabla2} {alias2}";
+            // SELECT ... JOIN ... ON ... -> π(R ⋈ S).
             return $"π_{{{unionNaturalSql.Groups[1].Value.Trim()}}}({izquierda} ⋈_{{{unionNaturalSql.Groups[6].Value.Trim()}}} {derecha})";
         }
 
@@ -145,6 +168,7 @@ WHERE NOT EXISTS (
             var tabla = proyeccionSql.Groups[2].Value.Trim();
             var alias = proyeccionSql.Groups[3].Value.Trim();
             var tablaResuelta = string.IsNullOrEmpty(alias) ? tabla : $"{tabla} {alias}";
+            // SELECT ... FROM ... -> π(R).
             return $"π_{{{proyeccionSql.Groups[1].Value.Trim()}}}({tablaResuelta})";
         }
 

--- a/Services/EspecializacionEerService.cs
+++ b/Services/EspecializacionEerService.cs
@@ -1,7 +1,13 @@
 using System.Linq;
 
+/// <summary>
+/// Servicio de alto nivel para combinar consultas de especialización y exponer un resultado simplificado.
+/// </summary>
 public interface IEspecializacionEerService
 {
+    /// <summary>
+    /// Determina si una jerarquía es total o parcial y si es disjunta o solapada.
+    /// </summary>
     EspecializacionInfo AnalizarEspecializacion(string conexion, string entidadPadre, params string[] entidadesHija);
 }
 
@@ -18,9 +24,11 @@ public class EspecializacionEerService : IEspecializacionEerService
     {
         var info = new EspecializacionInfo();
 
+        // Si no existe ningún registro del supertipo sin representación en subtipos, la especialización es total.
         var padresSin = _repositorio.ObtenerPadresSinHijo(conexion, entidadPadre, entidadesHija);
         info.EsTotal = !padresSin.Any();
 
+        // Se cuentan las intersecciones para inferir si los subtipos se solapan.
         var inter = _repositorio.ObtenerIntersecciones(conexion, entidadPadre, entidadesHija);
         info.EsDisjunta = inter == 0;
 

--- a/Utils/InferenciaEER.cs
+++ b/Utils/InferenciaEER.cs
@@ -1,18 +1,27 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
 
 
+/// <summary>
+/// Indica si la especialización identificada es exclusiva (disjunta) o permite solapamientos.
+/// </summary>
 public enum EerDisjointness { Exclusiva, Solapada, Ambiguous }
 
+/// <summary>
+/// Representa si todos los registros del supertipo participan en la especialización (total o parcial).
+/// </summary>
 public enum EerTotalness { Total, Parcial, Ambiguous }
 
 
 
 
 
+/// <summary>
+/// Modelo que resume una jerarquía EER detectada a partir del esquema relacional.
+/// </summary>
 public class JerarquiaEer
 {
     public string Supertipo { get; init; } = "";
@@ -21,11 +30,9 @@ public class JerarquiaEer
     public EerTotalness Totalidad { get; set; } = EerTotalness.Ambiguous;
 }
 
-
-
-
-
-
+/// <summary>
+/// Rutinas de análisis que transforman el esquema relacional en componentes EER y generan diagramas Mermaid.
+/// </summary>
 public static class InferenciaEER
 {
     
@@ -34,15 +41,21 @@ public static class InferenciaEER
     
     
     
+    /// <summary>
+    /// Busca patrones de herencia en las tablas para deducir jerarquías EER.
+    /// </summary>
+    /// <param name="s">Instantánea del esquema relacional.</param>
     public static List<JerarquiaEer> DetectarJerarquias(InstantaneaEsquema s)
     {
-        
+        // Se construye un diccionario con las columnas que forman la PK de cada tabla.
         var pkPorTabla = s.Tablas.ToDictionary(
             t => t.Nombre,
             t => s.Columnas.Where(c => c.Tabla == t.Nombre && c.EsPk).Select(c => c.Nombre).ToList(),
             StringComparer.OrdinalIgnoreCase);
 
-        
+        // Se filtran las claves foráneas que cumplen con la característica de especialización:
+        // 1) La tabla hija tiene una FK única hacia la tabla padre.
+        // 2) La FK usa exactamente las mismas columnas que la PK de la tabla hija.
         var candidatos = s.LlavesForaneas.Where(fk =>
         {
             if (!fk.HijaEsUnica) return false;
@@ -52,7 +65,7 @@ public static class InferenciaEER
             return pkCols.SequenceEqual(fkCols, StringComparer.OrdinalIgnoreCase);
         }).ToList();
 
-        
+        // Agrupa las FKs por tabla padre: cada grupo potencial representa una jerarquía.
         var grupos = candidatos.GroupBy(x => x.TablaPadre, StringComparer.OrdinalIgnoreCase);
         var lista = new List<JerarquiaEer>();
 
@@ -61,7 +74,7 @@ public static class InferenciaEER
             var j = new JerarquiaEer { Supertipo = g.Key };
             foreach (var fk in g) j.Subtipos.Add(fk.TablaHija);
 
-            
+            // Busca una columna de discriminador común con nombres habituales para ajustar la disyunción.
             var disc = s.Columnas.FirstOrDefault(c =>
                 c.Tabla.Equals(j.Supertipo, StringComparison.OrdinalIgnoreCase) &&
                 (c.Nombre.Equals("Tipo", StringComparison.OrdinalIgnoreCase) ||
@@ -72,11 +85,13 @@ public static class InferenciaEER
 
             if (disc is not null && !disc.EsNulo)
             {
+                // Un discriminador NOT NULL indica que cada registro del supertipo cae exactamente en un subtipo.
                 j.Disyuncion = EerDisjointness.Exclusiva;
                 j.Totalidad = EerTotalness.Ambiguous;
             }
             else
             {
+                // Sin discriminador se asume solapamiento cuando hay más de un subtipo.
                 j.Disyuncion = j.Subtipos.Count > 1 ? EerDisjointness.Solapada : EerDisjointness.Ambiguous;
                 j.Totalidad = EerTotalness.Ambiguous;
             }
@@ -90,6 +105,9 @@ public static class InferenciaEER
     
     
     
+    /// <summary>
+    /// Convierte la jerarquía EER detectada en instrucciones Mermaid para su representación visual.
+    /// </summary>
     public static string RenderMermaidEER(IReadOnlyList<JerarquiaEer> hs)
     {
         var sb = new StringBuilder();
@@ -101,6 +119,7 @@ public static class InferenciaEER
         int k = 0;
         foreach (var h in hs)
         {
+            // Se traduce el estado de disyunción y totalidad a etiquetas de texto para el diagrama.
             var tagDis = h.Disyuncion switch
             {
                 EerDisjointness.Exclusiva => "exclusiva",


### PR DESCRIPTION
## Summary
- add Spanish documentation file describing restoration, schema reading, diagram generation, relational model and translator flows
- expand inline XML comments in controllers, repositories and services to explain each step of restoring, inspecting and rendering the database artifacts

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_b_68c8a06edd10832588047441022c3a09